### PR TITLE
add functionality to sample from susie approximate posterior

### DIFF
--- a/R/sample_posterior.R
+++ b/R/sample_posterior.R
@@ -1,0 +1,48 @@
+#' @title Compute posterior samples from susie_fit.
+#'
+#' @param susie_fit A susie fit, the output form `susieR::susie()`
+#'
+#' @param num_samples the number of samples to be drawn from the posterior distribution
+#'
+#' @return The return value is a list containing the effect sizes samples and causal status samples
+#'    components:
+#'
+#'    \item{b}{ num_variables x num_samples matrix of effect sizes draw}
+#'
+#'    \item{gamma}{ num_variables  x num_samples matrix of causal status draw}
+#'
+#' @export
+#'
+
+susie_get_posterior_samples <- function(susie_fit, num_samples){
+    # removed effects having estimated prior variance equals zero
+    if (is.numeric(susie_fit$V)) {
+        include_idx = which(susie_fit$V > 1E-9)
+    }
+    else {
+        include_idx = 1:nrow(susie_fit$alpha)
+    }
+    
+    posterior_mean <- sweep(susie_fit$mu, 2, susie_fit$X_column_scale_factors, "/")
+    posterior_sd <- sweep(sqrt(susie_fit$mu2 - (susie_fit$mu)^2), 2, susie_fit$X_column_scale_factors, "/")
+
+    pip <- susie_fit$alpha
+    L = nrow(pip)
+    num_snps <- ncol(pip)
+    b_samples <- matrix(NA, num_snps, num_samples)
+    gamma_samples <- matrix(NA, num_snps, num_samples)
+    for (sample_i in 1 : num_samples){
+        b <- 0
+        for (l in include_idx){
+            gamma_l <- rmultinom(1, 1, pip[l, ])
+            effect_size <- rnorm(1, mean=posterior_mean[l, which(gamma_l != 0)], 
+                                    sd=posterior_sd[l, which(gamma_l != 0)])
+            b_l <- gamma_l * effect_size
+            b <- b + b_l
+        }
+        b_samples[, sample_i] <- b
+        gamma_samples[, sample_i] <- as.numeric(b != 0)
+    }
+    return(list(b=b_samples,
+                gamma=gamma_samples))
+}


### PR DESCRIPTION
Hi,

I add a file `R/sample_posterior.R` which performs approximate posterior samping to fix issue #66. We could discuss in more details in this pull request.

Related to this, we should remove effects having estimated prior variance equals zero in the following two functions for consistency.

https://github.com/stephenslab/susieR/blob/3ceeb94c51c93dc9b6720381bad083273f215132/R/susie_utils.R#L491-L500 

The follows is an informal unit test. I don't know what exact testing we should have here. Since samples are generated randomly, so the assertion would be probabilistic. I would like to know your ideas here.

```R
library(susieR)

# simulation adopted from https://stephenslab.github.io/susie-paper/manuscript_results/motivating_example.html
set.seed(1234)
n = 100
p = 10
b = rep(0,p)
b[2] = 1
b[8] = 1
X = matrix(rnorm(n*p),nrow=n,ncol=p)
X[,2] = X[,4]
X[,6] = X[,8]
y = X %*% b + rnorm(n)

# fit susie
susie_fit = susieR::susie(X, y, L=5,
    estimate_residual_variance=TRUE, 
    scaled_prior_variance=0.2,
    tol=1e-3, track_fit=TRUE, min_abs_corr=0.1)

# get posterior samples
num_samples <- 100000
posterior_samples <- susie_get_posterior_samples(susie_fit, num_samples)
print(susie_get_pip(susie_fit))
print(rowMeans(posterior_samples$gamma))
print(susie_get_posterior_mean(susie_fit))
print(rowMeans(posterior_samples$b))
```
This is the first time i contributed to a open source repository so feel free to let me know if there is any code practice i should follow here :)