### PR TITLE
fix bug in susie_rss when passing a named z vector

### DIFF
--- a/R/susie_rss.R
+++ b/R/susie_rss.R
@@ -142,7 +142,7 @@ susie_rss = function (z, R, maf = NULL, maf_thresh = 0, z_ld_weight = 0,
   Y = (t(attr(R,"eigen")$vectors[,attr(R,"eigen")$values != 0]) *
        attr(R,"eigen")$values[attr(R,"eigen")$values != 0]^(-0.5)) %*% z
   if (!is.null(names(z)))
-    colnames(x) = names(z)
+    colnames(X) = names(z)
 
   s = susie(X,Y,L = L,
             scaled_prior_variance = prior_variance/var(Y),


### PR DESCRIPTION
To see bug, try
```library(susieR)
data(N3finemapping)
attach(N3finemapping)
sumstats <- univariate_regression(X, Y[,1])
z_scores <- sumstats$betahat / sumstats$sebetahat
R <- cor(X)
## this runs fine
fitted_rss <- susie_rss(z_scores, R, L = 10,
                          estimate_residual_variance = TRUE,
                        estimate_prior_variance = TRUE)
## add names to z
names(z_scores)=paste0("nm",1:length(z_scores))
## this errors
fitted_rss <- susie_rss(z_scores, R, L = 10,
                          estimate_residual_variance = TRUE,
                        estimate_prior_variance = TRUE)
#Error in susie_rss(z_scores, R, L = 10, estimate_residual_variance = TRUE,  :
#  object 'x' not found```
The fix simply upcases x in the lines
```   if (!is.null(names(z)))
    colnames(x) = names(z)
```