### PR TITLE
Remove intercept in plot of coefficients in MWE vignette

### DIFF
--- a/vignettes/mwe.Rmd
+++ b/vignettes/mwe.Rmd
@@ -32,7 +32,7 @@ beta[c(1,2,300,400)] <- 1
 X   <- matrix(rnorm(n*p),nrow=n,ncol=p)
 y   <- X %*% beta + rnorm(n)
 res <- susie(X,y,L=10)
-plot(coef(res),pch = 20)
+plot(coef(res)[-1],pch = 20)
 ```
 
 Plot the ground-truth outcomes vs. the predicted outcomes:


### PR DESCRIPTION
When I was going through the MWE vignette, I was initially confused why the coefficients were off by 1. I realized when I was reading the example in `?susie` that the first coefficient is the intercept.

https://github.com/stephenslab/susieR/blob/0e48c3c9492b47aa000cbcd450be65c9ca9f9922/R/susie.R#L244

This PR similarly removes the intercept term from the coefficients plot.