### PR TITLE
Update dimensions for N3finemapping

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -56,8 +56,8 @@ NULL
 #'
 #' @docType data
 #'  
-#' @description The data-set contains a matrix of about 600
-#' individuals and 1,000 variables. These variables are real-world
+#' @description The data-set contains a matrix of 574
+#' individuals and 1,001 variables. These variables are real-world
 #' genotypes centered and scaled, and therefore retains the
 #' correlation structure of variables in the original genotype data. 3
 #' out of the variables have non-zero effects.  The response data is

--- a/vignettes/finemapping.Rmd
+++ b/vignettes/finemapping.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(collapse = TRUE,comment = "#",fig.width = 5,
 This vignette demonstrates `susieR` in the context of genetic
 fine-mapping.  We use simulated data of expression level of a gene
 ($y$) in $N \approx 600$ individuals.  We want to identify with the
-genotype matrix $X_{N\times P}$ ($P=1000$) the genetic variables that
+genotype matrix $X_{N\times P}$ ($P=1001$) the genetic variables that
 causes changes in expression level.
 
 The simulated data-set is [available

--- a/vignettes/finemapping_summary_statistics.Rmd
+++ b/vignettes/finemapping_summary_statistics.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(collapse = TRUE,comment = "#",fig.width = 5,
 
 This vignette demonstrates how to use `susieR` with "summary statistics" in the context of genetic fine-mapping. 
 We use the same simulated data as in [fine mapping vignette](finemapping.html). The simulated data is expression level of a gene ($y$) in $N \approx 600$ individuals. 
-We want to identify with the genotype matrix $X_{N\times P}$ ($P=1000$) the genetic variables that causes changes in expression level. The data-set is shipped with `susieR`. It is simulated to have exactly 3 non-zero effects.
+We want to identify with the genotype matrix $X_{N\times P}$ ($P=1001$) the genetic variables that causes changes in expression level. The data-set is shipped with `susieR`. It is simulated to have exactly 3 non-zero effects.
 
 ```{r}
 library(susieR)


### PR DESCRIPTION
The fine-mapping vignettes state that the example data has `P = 1000`. When I saw that there appeared to be 1,001 columns, I first assumed that maybe the first column was the intercept (similar to #118). But as far as I can tell, `univariate_regression()` automatically adds the intercept term:

https://github.com/stephenslab/susieR/blob/0e48c3c9492b47aa000cbcd450be65c9ca9f9922/R/univariate_regression.R#L68

And when I checked `N2finemapping`, its dimensions matched those in its documentation.