### PR TITLE
Speed-up for susie_plot

### DIFF
--- a/R/susie_plots.R
+++ b/R/susie_plots.R
@@ -175,6 +175,7 @@ susie_plot = function (model, y, add_bar = FALSE, pos = NULL, b = NULL,
   } else {
     if (!all(pos %in% 1:length(p))) 
       stop("Provided position is outside the range of variables")
+    pos_with_value = 1:length(p)
   }
   legend_text = list(col = vector(),purity = vector(),size = vector())
   # scipen0 = options()$scipen

--- a/R/susie_plots.R
+++ b/R/susie_plots.R
@@ -157,13 +157,10 @@ susie_plot = function (model, y, add_bar = FALSE, pos = NULL, b = NULL,
     end = max(max(model[[pos$attr]]),pos$end)
 
     # Add zeros to alpha and p.
-    alpha = matrix(0,nrow(model$alpha),end - start + 1)
-    new_p = rep(min(p),end - start + 1)
+    new_p = rep(NA,end - start + 1)
     pos_with_value = model[[pos$attr]] - start + 1
     new_p[pos_with_value] = p
-    alpha[,pos_with_value] = model$alpha
     p = new_p
-    model$alpha = alpha
 
     # Adjust model$cs.
     if (!is.null(model$sets$cs)) {
@@ -199,7 +196,7 @@ susie_plot = function (model, y, add_bar = FALSE, pos = NULL, b = NULL,
         y1 = p[x0]
       } else if (n_in_CS(model, model$sets$requested_coverage)[i] < max_cs) {
         x0 = intersect(pos,
-               which(in_CS(model,model$sets$requested_coverage)[i,] > 0))
+               pos[pos_with_value][which(in_CS(model,model$sets$requested_coverage)[i,] > 0)])
         y1 = p[x0]
       } else {
         x0 = NULL


### PR DESCRIPTION
The `susie_plot` function is slow when genomic positions are used. It also creates spurious points on the plot at genomic positions that are supposed to be empty. This pull request removes the spurious points  by using `NA` instead of `min(p)` to initialize empty positions. This results in a partial speed-up of the function. The rest of the speed-up is achieved by keeping `model$alpha` unchanged when genomic positions are specified. This means that `model$alpha` contains only non-empty positions, reducing runtime for the `in_CS` call. The output of the `in_CS` call is then matched back to non-empty positions.

Compare runtime and plot output with and without changes using this example code:

```
library(susieR)

#example data
set.seed(1)
n    <- 1000
p    <- 1000
beta <- rep(0,p)
beta[c(1,2,300,400)] <- 1
X   <- matrix(rnorm(n*p),nrow=n,ncol=p)
y   <- X %*% beta + rnorm(n)

res <- susie(X,y,L=10,
             compute_univariate_zscore = TRUE)

#sample positions over 2Mb range
pos <- sort(sample(1e6:3e6, p))
res$genomic_position <- pos

#plot without positions (fast)
ptm <- proc.time()
susie_plot(res, y="z")
proc.time() - ptm

#plot with positions; slow, creates artificial points at min(y) value vs previous plot
ptm <- proc.time()
susie_plot(res, y="z",
           pos = list(attr = "genomic_position", start=min(res$genomic_position), end=max(res$genomic_position)),
           xlab = "position")
proc.time() - ptm

```