### PR TITLE
Fixing edge case when na.rm=T and X has one column

### DIFF
--- a/R/susie.R
+++ b/R/susie.R
@@ -352,7 +352,7 @@ susie = function (X,y,L = min(10,ncol(X)),
     if (na.rm) {
       samples_kept = which(!is.na(y))
       y = y[samples_kept]
-      X = X[samples_kept,]
+      X = X[samples_kept,,drop=F]
     } else
       stop("Input y must not contain missing values")
   }


### PR DESCRIPTION
X changes from a matrix to a vector when `na.rm=T`, y has missing values, and X has one column. This throws an error on line 360 because `p=ncol(X)` is null