### PR TITLE
Compatibility with rpy2.

### DIFF
--- a/R/elbo_ss.R
+++ b/R/elbo_ss.R
@@ -29,4 +29,4 @@ get_ER2_ss = function (XtX, Xty, s, yty) {
 # @param Eb the posterior mean of b (p vector) (alpha * mu)
 # @param Eb2 the posterior second moment of b (p vector) (alpha * mu2)
 SER_posterior_e_loglik_ss = function (dXtX, Xty, s2, Eb, Eb2)
-  -0.5/s2 * (-2*sum(Eb*Xty) + sum(dXtX * as.vector(Eb2)))
+  -0.5/s2 * (-2*sum(Eb*as.vector(Xty)) + sum(dXtX * as.vector(Eb2)))

--- a/R/update_each_effect_ss.R
+++ b/R/update_each_effect_ss.R
@@ -27,7 +27,7 @@ update_each_effect_ss = function (XtX, Xty, s_init,
       s$XtXr = s$XtXr - XtX %*% (s$alpha[l,] * s$mu[l,])
 
       # Compute residuals.
-      XtR = Xty - s$XtXr
+      XtR = Xty - as.vector(s$XtXr)
       res = single_effect_regression_ss(as.matrix(XtR),attr(XtX,"d"),s$V[l],
               s$sigma2,s$pi,estimate_prior_method,check_null_threshold)
       


### PR DESCRIPTION
rpy2 (python -> R bridge) does not handle operations between vectors and matrices the same way that R does. 

Without these changes, there is an error due to "Error in Xty - s$XtXr : non-conformable arrays". These two small `as.vector` changes allow susieR to be callable from python.