### PR TITLE
improve univariate_regression efficiency by ~16x

### DIFF
--- a/R/univariate_regression.R
+++ b/R/univariate_regression.R
@@ -51,6 +51,7 @@
 univariate_regression = function (X, y, Z = NULL, center = TRUE,
                                   scale = FALSE, return_residuals = FALSE,
                                   method = c("sumstats", "lmfit")) {
+  method <- match.arg(method)
   y_na = which(is.na(y))
   if (length(y_na)) {
     X = X[-y_na,]
@@ -70,7 +71,7 @@ univariate_regression = function (X, y, Z = NULL, center = TRUE,
 
   # fast implementation: computes X'X and X'y without forming X
   if (method == "sumstats") {
-    output = try(output <- try({
+    output <- try({
                 n  <- length(y)
                 sy <- sum(y)
                 yy <- sum(y * y)
@@ -110,7 +111,7 @@ univariate_regression = function (X, y, Z = NULL, center = TRUE,
                 }
 
                 res
-              }, silent = TRUE))
+              }, silent = TRUE)
   } else {
     # original .lm.fit-based implementation
     output = try(do.call(rbind,


### PR DESCRIPTION
Currently each univariate regression is forming the n*2 matrix of covariates and then brute-forcing the regressions by calling `stats.lm.fit`. 

A more efficient approach is to simply compute X'X (2 by 2 matrix) and X'y (2 by 1 vector) without ever creating X, and then solving the normal equation directly. This is ~16x faster than existing code on my macbook air. 

```
set.seed(1)
n = 1000
p = 1000
beta = rep(0,p)
beta[1:4] = 1
X = matrix(rnorm(n*p),nrow = n,ncol = p)
X = scale(X,center = TRUE,scale = TRUE)
y = drop(X %*% beta + rnorm(n))

# old function
system.time({
  res = univariate_regression(X,y)
  })
   user  system elapsed 
  0.604   0.016   0.620 

# new function
system.time({
  res2 = univariate_regression(X,y)
  })
   user  system elapsed 
  0.035   0.003   0.038

# check answer is correct
head(res$betahat)
[1]  1.14409495  1.06973914  1.09131783  1.04125247 -0.12465851 -0.07313538
head(res2$betahat)
[1]  1.14409495  1.06973914  1.09131783  1.04125247 -0.12465851 -0.07313538

# check answer is correct
> head(res$sebetahat)
[1] 0.06424989 0.06552091 0.06516336 0.06597913 0.07364817 0.07371747
> head(res2$sebetahat)
[1] 0.06424989 0.06552091 0.06516336 0.06597913 0.07364817 0.07371747
```

Let me know if you want me to do anything else. 