### PR TITLE
Fix multi-panel omega weights

### DIFF
--- a/R/ss_mixture_methods.R
+++ b/R/ss_mixture_methods.R
@@ -79,6 +79,15 @@ update_model_variance.ss_mixture <- function(data, params, model) {
   if (!is.null(data$K) && data$K > 1 && !isTRUE(model$omega_converged)) {
     omega_cur <- if (!is.null(model$omega)) model$omega else rep(1 / data$K, data$K)
 
+    # Omega-objective ridge: small floor used ONLY inside the Eloglik
+    # evaluator to stabilize log|sigma2*A(omega)| near rank-deficient
+    # vertices. Without it, small eigenvalues of A(omega) produce a huge
+    # -0.5 * log|.| penalty at vertex omegas, pulling the optimizer toward
+    # the interior (collapse to ~uniform weights). Matches the behavior
+    # of the prev rss_lambda path with auto lambda = 1/(n-1). Does NOT
+    # affect the ss-SER update, which still uses lambda = 0 (no FDR
+    # inflation in the credible-set inference).
+    omega_ridge <- 1 / data$nm1
     eval_omega <- NULL
     if (!is.null(data$omega_cache)) {
       cache <- data$omega_cache
@@ -86,13 +95,13 @@ update_model_variance.ss_mixture <- function(data, params, model) {
                                                 model$diag_postb2, model$Z)
       eval_omega <- function(w) {
         eval_omega_eloglik_reduced(cache, w, iter_cache,
-                                    model$sigma2, 0, data$K, data$p)
+                                    model$sigma2, omega_ridge, data$K, data$p)
       }
     } else if (!is.null(data$panel_R)) {
       eval_omega <- function(w) {
         eval_omega_eloglik_R(data$panel_R, w, data$z, model$zbar,
                               model$diag_postb2, model$Z, model$sigma2,
-                              0, data$K, data$p)
+                              omega_ridge, data$K, data$p)
       }
     }
 

--- a/R/susie_rss_utils.R
+++ b/R/susie_rss_utils.R
@@ -437,8 +437,12 @@ eval_omega_eloglik_reduced <- function(cache, omega, iter_cache,
   term5 <- sum(diag(Sinv_AMA))
 
   ER2 <- zSinvz + term2 + term3 + term4 + term5
-  logdet_use <- if (lambda > 0) logdet_term else 0
-  -p_eff / 2 * log(2 * pi) + logdet_use - 0.5 * ER2
+  # Always include the column-space log|S(omega)|: it is omega-dependent and
+  # is the primary driver of mixture weight selection. At lambda=0 the
+  # null-space pieces (logdet_null, z_null_norm2/lambda) are constants in
+  # omega given the joint reduced basis, so dropping them is fine --- but
+  # dropping logdet_term itself erases the omega signal.
+  -p_eff / 2 * log(2 * pi) + logdet_term - 0.5 * ER2
 }
 
 # Recover full eigendecomposition from reduced basis after omega is chosen.
@@ -503,8 +507,8 @@ eval_omega_eloglik_R <- function(panel_R, omega, z, zbar, diag_postb2, Z,
 
   ER2 <- zSinvz + term2 + term3 + term4 + term5
   p_eff <- length(S_pos)
-  logdet_use <- if (lambda > 0) logdet_term else 0
-  -p_eff / 2 * log(2 * pi) + logdet_use - 0.5 * ER2
+  # See eval_omega_eloglik_reduced: always keep column-space logdet_term.
+  -p_eff / 2 * log(2 * pi) + logdet_term - 0.5 * ER2
 }
 
 # Optimize omega on the K-simplex by maximizing eval_fn.


### PR DESCRIPTION
In the multi-panel SuSiE-RSS model, the parameter lambda was doing two very different jobs at the same time, and they were pulling in opposite directions.

Job 1 — regularizing the SER (fine-mapping step). Here, lambda adds a floor to the LD eigenvalues when we invert them. A large lambda inflates the standard errors shat² of each SNP's effect, which widens credible sets and, in the cases I tested, caused the true causal variant to drop out of the CS. So for clean fine-mapping we want lambda as small as possible — ideally zero.

Job 2 — stabilizing the panel-weight (omega) update. Omega is chosen by maximizing a profile likelihood that contains a log |R(omega)| term. Near a vertex — say, "use UKB only, ignore ROSMAP" — the combined LD matrix R(omega) becomes rank-deficient (many eigenvalues near zero), so log |R(omega)| blows up to a huge negative number. This creates an artificial penalty against vertex solutions: the optimizer sees a cliff at exactly the answers we actually want, and retreats toward the middle. That's why we were getting ~0.5/0.5 weights even in simulations where we knew the truth was ~0/1. A small lambda inside this log-det term acts as a numerical floor that smooths away the cliff, without changing where the maximum actually lies.

Job 1 wants lambda → 0. Job 2 needs lambda non-trivially positive. The previous code used a single lambda for both, so we had to pick a compromise.

We split the two roles of lambda:

The fine-mapping step runs with lambda = 0 (no variance inflation, no FDR).

The omega optimizer internally uses a small ridge 1/(n-1) — purely a numerical stabilizer for the log-determinant, sized to the GWAS sample scale, invisible to the CS output.