### PR TITLE
Fix implementation of `susie_post_outcome_configuration` function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,8 +15,8 @@ Description: Implements methods for variable selection in linear
     called "Iterative Bayesian Stepwise Selection" (IBSS), is simple
     and fast, allowing the SuSiE model be fit to large data sets
     (thousands of samples and hundreds of thousands of variables).
-Date: 2026-06-03
-Version: 0.16.3
+Date: 2026-06-07
+Version: 0.16.4
 Authors@R: c(person("Gao","Wang",role="aut",email="wang.gao@columbia.edu"),
              person("Yuxin","Zou",role="aut"),
              person("Alexander","McCreight",role="aut"),

--- a/R/susie_post_outcome_configuration.R
+++ b/R/susie_post_outcome_configuration.R
@@ -76,13 +76,29 @@
 #' trait 2 only; H3, two distinct causal variants; and H4, one shared causal
 #' variant. Thus coloc splits the active two-trait case into H3 and H4,
 #' whereas SuSiEx represents it as the single activation state \eqn{(1,1)}.
-#' }
-#'
-#' The \code{"susiex"} output is an \eqn{N}-trait post-hoc activation model
+#' 
+#' The \code{"susiex"} output is an \eqn{2}-trait post-hoc activation model
 #' over CS tuples. The \code{"coloc_pairwise"} output is a pairwise
 #' colocalisation model over H0-H4 for each CS pair. Both are summaries of
 #' already fitted SuSiE-class models; neither refits the single-trait effects.
-#'
+#' }
+#' 
+#' More generally, in \eqn{N}-trait analysis, the difference between
+#' SuSiEx-style activation and colocalization is a difference in hypothesis
+#' space:
+#' \describe{
+#'   \item{SuSiEx activation space}{\code{"susiex"} is an \eqn{N}-trait
+#'     post-hoc activation, or meta-analysis-style, model over CS tuples. It
+#'     enumerates the \eqn{2^N} binary activity patterns and asks which traits
+#'     participate in a proposed shared event.}
+#'   \item{Colocalization partition space}{A theoretical generalization to
+#'     \eqn{N}-trait colocalization has a larger hypothesis space: inactive
+#'     traits plus all ways of grouping active traits by shared causal
+#'     variant, of size Bell(\eqn{N+1}) (see HyPrColoc, Figure 1). This space
+#'     asks not only which traits are active, but which active traits share
+#'     the same causal variant versus distinct causal variants.}
+#' }
+#' 
 #' @param input A single fit of class \code{susie}, \code{mvsusie}, or
 #'   \code{mfsusie}, OR a list of such fits.
 #' @param by Either \code{"fit"} (one trait per input fit; default) or
@@ -126,6 +142,8 @@
 #' @references
 #' SuSiEx, Nature Genetics 2024 (combinatorial \eqn{2^N} enumeration).
 #' Wallace, PLoS Genetics 2020 (coloc pairwise H0/H1/H2/H3/H4 ABF).
+#' Foley et al., Nature Communications 2021 (HyPrColoc; multi-trait
+#' colocalisation hypothesis space in Figure 1).
 #'
 #' @export
 susie_post_outcome_configuration <- function(input,

--- a/R/susie_post_outcome_configuration.R
+++ b/R/susie_post_outcome_configuration.R
@@ -104,6 +104,10 @@
 #'   \code{mfsusie}, OR a list of such fits.
 #' @param by Either \code{"fit"} (one trait per input fit; default) or
 #'   \code{"outcome"} (multi-output fits expand into per-outcome traits).
+#' @param outcome_names Optional character vector of trait-view names. If
+#'   \code{NULL}, names are taken from the input list when available, otherwise
+#'   \code{trait_1}, \code{trait_2}, ... are used. If provided, its length must
+#'   match the number of trait views after applying \code{by}.
 #' @param method Character scalar; one of \code{"susiex"} (default) or
 #'   \code{"coloc_pairwise"}. Pick the analysis to run; for both, call
 #'   the function twice.
@@ -149,6 +153,7 @@
 #' @export
 susie_post_outcome_configuration <- function(input,
                                              by          = c("fit", "outcome"),
+                                             outcome_names = NULL,
                                              method      = c("susiex",
                                                              "coloc_pairwise"),
                                              prob_thresh = 0.8,
@@ -175,7 +180,8 @@ susie_post_outcome_configuration <- function(input,
     }
   }
 
-  views <- normalise_to_views(input, by = by, cs_only = cs_only)
+  views <- normalise_to_views(input, by = by, cs_only = cs_only,
+                              outcome_names = outcome_names)
 
   out <- list()
   if (identical(method, "susiex")) {
@@ -203,7 +209,7 @@ is_susie_fit <- function(x) {
   inherits(x, "susie") || inherits(x, "mvsusie") || inherits(x, "mfsusie")
 }
 
-normalise_to_views <- function(input, by, cs_only) {
+normalise_to_views <- function(input, by, cs_only, outcome_names = NULL) {
   fits <- if (is_susie_fit(input)) list(input) else as.list(input)
 
   if (length(fits) == 0L) {
@@ -230,6 +236,17 @@ normalise_to_views <- function(input, by, cs_only) {
   views <- vector("list", 0)
   for (k in seq_along(fits)) {
     views <- c(views, expand_one_fit(fits[[k]], raw_names[k], by = by))
+  }
+  if (!is.null(outcome_names)) {
+    if (!is.character(outcome_names) ||
+        length(outcome_names) != length(views) ||
+        anyNA(outcome_names) || any(!nzchar(outcome_names))) {
+      stop("`outcome_names` must be a non-empty character vector with ",
+           "length equal to the number of trait views.")
+    }
+    for (k in seq_along(views)) {
+      views[[k]]$name <- outcome_names[k]
+    }
   }
   views
 }

--- a/R/susie_post_outcome_configuration.R
+++ b/R/susie_post_outcome_configuration.R
@@ -26,8 +26,8 @@
 #'
 #' Runs one of two complementary post-hoc analyses, selected by
 #' \code{method}: \code{"susiex"} (default) for the SuSiEx \eqn{2^N}
-#' combinatorial enumeration, reporting the posterior probability of
-#' every binary causality pattern across the \eqn{N} input traits; or
+#' combinatorial enumeration, reporting posterior probabilities over
+#' binary causality patterns across the \eqn{N} input traits; or
 #' \code{"coloc_pairwise"} for the coloc pairwise ABF, reporting the
 #' five colocalisation hypothesis posteriors (H0/H1/H2/H3/H4) for every
 #' pair of traits. To get both, call the function twice and combine.
@@ -50,75 +50,40 @@
 #'     fit (set \code{attach_lbf_variable_outcome = TRUE} when fitting).}
 #' }
 #'
-#' \subsection{SuSiEx algorithm}{
-#' For each credible-set tuple \eqn{(l_1, \dots, l_N)}, the \code{"susiex"}
-#' method computes post hoc probabilities of causal configurations following
-#' the SuSiEx activation-configuration framework.
-#'
-#' \enumerate{
-#'   \item Enumerate the \eqn{2^N} activation configurations
-#'     \eqn{c \in \{0,1\}^N}. Here \eqn{c_n = 1} indicates that, under this
-#'     configuration, the signal in the tuple is causal in trait / population
-#'     \eqn{n}.
-#'   \item For \eqn{c \ne 0}, score the configuration on aligned variants
-#'     \eqn{\mathcal V_c = \cap_{n:c_n=1}\mathcal V_n}:
-#'     \deqn{\log W(c) =
-#'       \log\sum_{j \in \mathcal V_c} \pi_j
-#'       \exp\{\sum_{n:c_n=1}\log\mathrm{BF}_{n,l_n,j}\},}
-#'     with \eqn{\pi_j} uniform over aligned variants and \eqn{\log W(0)=0}.
-#'   \item Normalise under a uniform prior over the \eqn{2^N} activation
-#'     configurations.
-#'   \item Per-trait marginal: \eqn{P(\mathrm{trait}\,n\,\mathrm{causal}) =
-#'     \sum_{c: c_n = 1} P(c \mid \mathrm{tuple})}.
+#' After SuSiE has been fit, the post-hoc step can answer two related
+#' questions:
+#' \describe{
+#'   \item{\code{"susiex"}}{SuSiEx \eqn{2^N} activation probabilities for
+#'     each credible-set tuple. It asks which traits have evidence for a
+#'     proposed shared CS-level event. In two traits, the both-active state
+#'     uses same-SNP evidence such as
+#'     \eqn{\sum_j \exp(\ell_{1j}+\ell_{2j})}, where \eqn{\ell_{tj}} is the
+#'     SNP-level log Bayes factor for trait \eqn{t}.}
+#'   \item{\code{"coloc_pairwise"}}{Pairwise coloc H0-H4 posteriors for
+#'     every trait pair and CS pair. It asks whether same-SNP evidence is
+#'     stronger than distinct-causal evidence, represented by terms such as
+#'     \eqn{\sum_{j \ne k}\exp(\ell_{1j}+\ell_{2k})}; this separates H3,
+#'     two distinct causal variants, from H4, one shared causal variant.}
 #' }
 #'
-#' The \eqn{2^N} activation space is a coherent post hoc model for a candidate
-#' credible-set event. It is especially useful in cross-population fine-mapping,
-#' where a proposed shared causal event may be causal or detectable in only a
-#' subset of populations because of differences in LD, allele frequency, sample
-#' size, or effect size.
+#' \subsection{Two-trait example}{
+#' For two traits and one CS pair, SuSiEx has four activation states:
+#' \eqn{(0,0)}, \eqn{(1,0)}, \eqn{(0,1)}, and \eqn{(1,1)}. The state
+#' \eqn{(1,1)} means both traits are active for the candidate shared event;
+#' it does not introduce a separate distinct-causal state.
 #'
-#' This activation space should be distinguished from the complete coloc-style
-#' sharing space. A complete colocalisation model also allows active traits to
-#' split into distinct causal groups. With inactive traits allowed, this is a
-#' partial-partition space of size Bell(\eqn{N+1}). In other words,
-#' SuSiEx-style activation asks which traits participate in one candidate
-#' event, whereas a complete coloc-style model asks how active traits are
-#' partitioned into one or more causal events.
-#'
-#' For two traits, the SuSiEx-style activation space contains
-#' \eqn{H(0,0)}, \eqn{H(1,0)}, \eqn{H(0,1)}, and \eqn{H(1,1)}. Coloc further
-#' separates the active state \eqn{H(1,1)} into two competing explanations:
-#' H3, where both traits are active but have distinct causal variants, and H4,
-#' where both traits share one causal variant.
-#'
+#' Coloc has five hypotheses: H0, no causal variant; H1, trait 1 only; H2,
+#' trait 2 only; H3, two distinct causal variants; and H4, one shared causal
+#' variant. Thus coloc splits the active two-trait case into H3 and H4,
+#' whereas SuSiEx represents it as the single activation state \eqn{(1,1)}.
 #' }
 #'
-#' \subsection{Coloc pairwise algorithm}{
-#' For each unordered trait pair \eqn{(n, n')} and each CS pair
-#' \eqn{(l_n, l_{n'})}, with per-SNP log BFs
-#' \eqn{\ell_1 = \log\mathrm{BF}_{n,l_n,\cdot}} and
-#' \eqn{\ell_2 = \log\mathrm{BF}_{n',l_{n'},\cdot}} (length \eqn{J}), the
-#' five hypothesis log-BFs are
-#' \deqn{\log\mathrm{BF}_{H_0} = 0,\quad
-#'       \log\mathrm{BF}_{H_1} = \log p_1 + \mathrm{LSE}(\ell_1),\quad
-#'       \log\mathrm{BF}_{H_2} = \log p_2 + \mathrm{LSE}(\ell_2),}
-#' \deqn{\log\mathrm{BF}_{H_3} = \log p_1 + \log p_2 +
-#'       \mathrm{logdiff}(\mathrm{LSE}(\ell_1) + \mathrm{LSE}(\ell_2),\;
-#'                        \mathrm{LSE}(\ell_1 + \ell_2)),}
-#' \deqn{\log\mathrm{BF}_{H_4} = \log p_{12} + \mathrm{LSE}(\ell_1 + \ell_2),}
-#' and the corresponding posteriors are
-#' \eqn{\mathrm{PP.H}_h = \exp(\log\mathrm{BF}_{H_h} -
-#'       \mathrm{LSE}(\log\mathrm{BF}_{H_0:H_4}))}, where
-#' \eqn{\mathrm{LSE}} is the log-sum-exp.
-#' \itemize{
-#'   \item H0: no causal variant in either CS.
-#'   \item H1: causal in trait \eqn{n} only.
-#'   \item H2: causal in trait \eqn{n'} only.
-#'   \item H3: distinct causals in the two traits.
-#'   \item H4: a single shared causal variant.
-#' }
-#' }
+#' The \code{"susiex"} output is an \eqn{N}-trait post-hoc activation model
+#' over CS tuples. The \code{"coloc_pairwise"} output is a pairwise
+#' colocalisation model over H0-H4 for each CS pair. Both are summaries of
+#' already fitted SuSiE-class models; neither refits the single-trait effects.
+#'
+#' To get both methods, call the function twice and combine the outputs.
 #'
 #' @param input A single fit of class \code{susie}, \code{mvsusie}, or
 #'   \code{mfsusie}, OR a list of such fits.

--- a/R/susie_post_outcome_configuration.R
+++ b/R/susie_post_outcome_configuration.R
@@ -120,6 +120,10 @@
 #'   for multiple analyses, call the function more than once.
 #' @param prob_thresh Per-trait marginal threshold for the convenience
 #'   \code{$active} flags in the SuSiEx output. Default \code{0.8}.
+#' @param single_effect_lfsr_cutoff LFSR threshold used to flag mvSuSiE
+#'   outcome-specific CS evidence in the \code{"mvsusie"} summary.
+#'   The LFSR is read from \code{fit$lfsr} at each CS sentinel SNP.
+#'   Default \code{0.05}.
 #' @param cs_only Logical. If \code{TRUE} (default) only enumerate over CSs
 #'   present in each fit's \code{$sets$cs}; if \code{FALSE} loop over all L
 #'   rows of \code{$alpha}. Either way, effects whose entire alpha row is
@@ -147,11 +151,11 @@
 #'     A data.frame with one row per (trait1, trait2, l1, l2)
 #'     combination, columns \code{trait1, trait2, l1, l2, hit1, hit2,
 #'     PP.H0, PP.H1, PP.H2, PP.H3, PP.H4}.}
-#'   \item{\code{$mvsusie}}{(when \code{method = "mvsusie"}) A CS-level
-#'     data.frame for one multi-output \code{mvsusie} or \code{mfsusie}
-#'     fit. The table organizes mvSuSiE-native quantities: CS label,
-#'     single-effect index, sentinel hit, max PIP, overall log BF,
-#'     per-outcome log BF, and \code{single_effect_lfsr}.}
+#'   \item{\code{$mvsusie}}{(when \code{method = "mvsusie"}) Summarizes one
+#'     multi-output \code{mvsusie} or \code{mfsusie} fit by CS, returning
+#'     \code{cs_summary}, \code{config_summary} (outcome log BF, sentinel
+#'     LFSR, cutoff flag), and \code{cs_variant_summary} (CS variant PIP and
+#'     outcome-specific LFSR).}
 #' }
 #' Pretty-print with \code{summary(out)}.
 #'
@@ -166,9 +170,10 @@ susie_post_outcome_configuration <- function(input,
                                              by          = c("fit", "outcome"),
                                              outcome_names = NULL,
                                              method      = c("susiex",
-                                                             "coloc_pairwise",
-                                                             "mvsusie"),
+                                             "coloc_pairwise",
+                                             "mvsusie"),
                                              prob_thresh = 0.8,
+                                             single_effect_lfsr_cutoff = 0.05,
                                              cs_only     = TRUE,
                                              p1          = 1e-4,
                                              p2          = 1e-4,
@@ -180,6 +185,12 @@ susie_post_outcome_configuration <- function(input,
   if (!is.numeric(prob_thresh) || length(prob_thresh) != 1L ||
       !is.finite(prob_thresh) || prob_thresh < 0 || prob_thresh > 1) {
     stop("`prob_thresh` must be a single numeric in [0, 1].")
+  }
+  if (!is.numeric(single_effect_lfsr_cutoff) ||
+      length(single_effect_lfsr_cutoff) != 1L ||
+      !is.finite(single_effect_lfsr_cutoff) ||
+      single_effect_lfsr_cutoff < 0 || single_effect_lfsr_cutoff > 1) {
+    stop("`single_effect_lfsr_cutoff` must be a single numeric in [0, 1].")
   }
   if (!is.logical(cs_only) || length(cs_only) != 1L || is.na(cs_only)) {
     stop("`cs_only` must be a single logical (TRUE or FALSE).")
@@ -196,6 +207,8 @@ susie_post_outcome_configuration <- function(input,
   if (identical(method, "mvsusie")) {
     out$mvsusie <- mvsusie_cs_summary(input,
                                       outcome_names = outcome_names,
+                                      single_effect_lfsr_cutoff =
+                                        single_effect_lfsr_cutoff,
                                       cs_only       = cs_only)
     if (is.null(out$mvsusie)) return(NULL)
   } else {
@@ -227,6 +240,7 @@ susie_post_outcome_configuration <- function(input,
     }
   }
   attr(out, "prob_thresh") <- prob_thresh
+  attr(out, "single_effect_lfsr_cutoff") <- single_effect_lfsr_cutoff
   attr(out, "method")      <- method
   class(out) <- c("susie_post_outcome_configuration", "list")
   out
@@ -625,7 +639,9 @@ mvsusie_cs_indices <- function(fit, cs_only) {
 
 mvsusie_cs_hit <- function(fit, label, idx, variable_names) {
   cs <- fit$sets$cs
-  empty <- list(n_cs = 0L, hit = NA_character_, maxPIP = NA_real_)
+  empty <- list(n_cs = 0L, hit_idx = NA_integer_, hit = NA_character_,
+                maxPIP = NA_real_, variants = character(0),
+                variant_idx = integer(0), pips = numeric(0))
   if (is.null(cs) || length(cs) == 0L) return(empty)
 
   pos <- if (!is.null(names(cs))) match(label, names(cs)) else NA_integer_
@@ -636,28 +652,42 @@ mvsusie_cs_hit <- function(fit, label, idx, variable_names) {
   if (is.na(pos) || pos < 1L || pos > length(cs)) return(empty)
 
   members <- cs[[pos]]
+  member_idx <- if (is.character(members)) {
+    match(members, variable_names)
+  } else {
+    as.integer(members)
+  }
+  member_idx <- member_idx[!is.na(member_idx) &
+                             member_idx >= 1L &
+                             member_idx <= length(variable_names)]
+  variants <- variable_names[member_idx]
+
   if (length(members) == 0L || is.null(fit$pip)) {
     empty$n_cs <- length(members)
+    empty$variants <- variants
+    empty$variant_idx <- member_idx
+    empty$pips <- rep(NA_real_, length(variants))
     return(empty)
   }
-  if (is.character(members)) {
-    idx <- match(members, variable_names)
-  } else {
-    idx <- as.integer(members)
-  }
-  idx <- idx[!is.na(idx) & idx >= 1L & idx <= length(fit$pip)]
-  if (length(idx) == 0L) {
+  member_idx <- member_idx[member_idx <= length(fit$pip)]
+  if (length(member_idx) == 0L) {
     empty$n_cs <- length(members)
+    empty$variants <- variants
+    empty$variant_idx <- member_idx
+    empty$pips <- rep(NA_real_, length(variants))
     return(empty)
   }
 
-  pip <- fit$pip[idx]
-  best <- idx[which.max(pip)]
-  list(n_cs = length(members), hit = variable_names[best],
-       maxPIP = unname(fit$pip[best]))
+  pip <- fit$pip[member_idx]
+  best <- member_idx[which.max(pip)]
+  list(n_cs = length(members), hit_idx = best, hit = variable_names[best],
+       maxPIP = unname(fit$pip[best]), variants = variants,
+       variant_idx = member_idx, pips = pip)
 }
 
-mvsusie_cs_summary <- function(input, outcome_names = NULL, cs_only) {
+mvsusie_cs_summary <- function(input, outcome_names = NULL,
+                               single_effect_lfsr_cutoff = 0.05,
+                               cs_only) {
   fit <- as_single_mvsusie_fit(input)
   logBF_mat <- mvsusie_lbf_outcome(fit)
   if (nrow(logBF_mat) != nrow(fit$alpha)) {
@@ -671,7 +701,7 @@ mvsusie_cs_summary <- function(input, outcome_names = NULL, cs_only) {
     return(NULL)
   }
   trait_names <- mvsusie_names(
-    list(colnames(fit$lbf_outcome), colnames(fit$single_effect_lfsr),
+    list(colnames(fit$lbf_outcome), colnames(fit$lfsr),
          fit$outcome_names,
          if (!is.null(fit$lbf_variable_outcome)) {
            dimnames(fit$lbf_variable_outcome)[[3L]]
@@ -687,8 +717,10 @@ mvsusie_cs_summary <- function(input, outcome_names = NULL, cs_only) {
     return(NULL)
   }
 
-  lfsr_mat <- fit$single_effect_lfsr
-  if (!is.null(lfsr_mat) && !is.matrix(lfsr_mat)) lfsr_mat <- as.matrix(lfsr_mat)
+  sentinel_lfsr_mat <- fit$lfsr
+  if (!is.null(sentinel_lfsr_mat) && !is.matrix(sentinel_lfsr_mat)) {
+    sentinel_lfsr_mat <- as.matrix(sentinel_lfsr_mat)
+  }
   effect_lbf <- rep(NA_real_, nrow(fit$alpha))
   if (!is.null(fit$lbf)) {
     lbf <- as.numeric(unlist(fit$lbf, use.names = FALSE))
@@ -705,31 +737,66 @@ mvsusie_cs_summary <- function(input, outcome_names = NULL, cs_only) {
     l <- cs$idx[i]
     if (all(fit$alpha[l, ] == 0)) next
 
-    single_effect_lfsr <- rep(NA_real_, R)
-    if (!is.null(lfsr_mat) && nrow(lfsr_mat) >= l && ncol(lfsr_mat) == R) {
-      single_effect_lfsr <- as.numeric(lfsr_mat[l, ])
-    }
-
     hit <- mvsusie_cs_hit(fit, label = cs$labels[i], idx = l,
                           variable_names = variable_names)
-    row <- data.frame(
+    sentinel_lfsr <- rep(NA_real_, R)
+    if (!is.null(sentinel_lfsr_mat) &&
+        !is.na(hit$hit_idx) &&
+        nrow(sentinel_lfsr_mat) >= hit$hit_idx &&
+        ncol(sentinel_lfsr_mat) == R) {
+      sentinel_lfsr <- as.numeric(sentinel_lfsr_mat[hit$hit_idx, ])
+    }
+    sentinel_lfsr_pass <- sentinel_lfsr < single_effect_lfsr_cutoff
+
+    cs_summary <- data.frame(
       cs            = cs$labels[i],
       single_effect = l,
       n_cs          = hit$n_cs,
       hit           = hit$hit,
       maxPIP        = hit$maxPIP,
       lbf           = effect_lbf[l],
+      n_lfsr_pass   = sum(sentinel_lfsr_pass, na.rm = TRUE),
       stringsAsFactors = FALSE,
       check.names = FALSE
     )
-    row[paste0("lbf_outcome.", trait_names)] <- as.list(as.numeric(logBF_mat[l, ]))
-    row[paste0("single_effect_lfsr.", trait_names)] <- as.list(single_effect_lfsr)
-    out[[i]] <- row
+    cs_variant_summary <- data.frame(
+      variant = hit$variants,
+      pip = unname(hit$pips),
+      stringsAsFactors = FALSE,
+      check.names = FALSE
+    )
+    if (!is.null(sentinel_lfsr_mat) &&
+        length(hit$variant_idx) > 0L &&
+        length(hit$variant_idx) == length(hit$variants) &&
+        nrow(sentinel_lfsr_mat) >= max(hit$variant_idx, na.rm = TRUE) &&
+        ncol(sentinel_lfsr_mat) == R) {
+      cs_lfsr <- sentinel_lfsr_mat[hit$variant_idx, , drop = FALSE]
+      for (r in seq_len(R)) {
+        cs_variant_summary[[paste0("lfsr_", trait_names[r])]] <- cs_lfsr[, r]
+      }
+    } else {
+      for (trait in trait_names) {
+        cs_variant_summary[[paste0("lfsr_", trait)]] <-
+          rep(NA_real_, nrow(cs_variant_summary))
+      }
+    }
+
+    config_summary <- data.frame(
+      outcome = trait_names,
+      lbf_outcome = as.numeric(logBF_mat[l, ]),
+      sentinel_lfsr = sentinel_lfsr,
+      lfsr_pass = sentinel_lfsr_pass,
+      stringsAsFactors = FALSE,
+      check.names = FALSE
+    )
+    out[[i]] <- list(cs_summary = cs_summary,
+                     config_summary = config_summary,
+                     cs_variant_summary = cs_variant_summary)
   }
 
   out <- out[!vapply(out, is.null, logical(1))]
-  if (length(out) == 0L) return(data.frame())
-  do.call(rbind, out)
+  names(out) <- vapply(out, function(x) x$cs_summary$cs[[1]], character(1))
+  out
 }
 
 # -----------------------------------------------------------------------------

--- a/R/susie_post_outcome_configuration.R
+++ b/R/susie_post_outcome_configuration.R
@@ -51,19 +51,47 @@
 #' }
 #'
 #' \subsection{SuSiEx algorithm}{
-#' For each credible-set tuple \eqn{(l_1, \dots, l_N)}:
+#' For each credible-set tuple \eqn{(l_1, \dots, l_N)}, the \code{"susiex"}
+#' method computes post hoc probabilities of causal configurations following
+#' the SuSiEx activation-configuration framework.
+#'
 #' \enumerate{
-#'   \item Per-trait CS-level log BF (alpha-weighted SNP average):
-#'     \deqn{\log\mathrm{BF}^{(n)}_{l_n} = \sum_j \alpha_{n,l_n,j}\,
-#'       \log\mathrm{BF}_{n,l_n,j}.}
-#'   \item Enumerate the \eqn{2^N} binary configurations
-#'     \eqn{c \in \{0,1\}^N}.
-#'   \item Configuration log BF:
-#'     \deqn{\log\mathrm{BF}^{(c)} = \sum_{n: c_n = 1} \log\mathrm{BF}^{(n)}_{l_n}.}
-#'   \item Normalise under a uniform prior over the \eqn{2^N} configurations.
+#'   \item Enumerate the \eqn{2^N} activation configurations
+#'     \eqn{c \in \{0,1\}^N}. Here \eqn{c_n = 1} indicates that, under this
+#'     configuration, the signal in the tuple is causal in trait / population
+#'     \eqn{n}.
+#'   \item For \eqn{c \ne 0}, score the configuration on aligned variants
+#'     \eqn{\mathcal V_c = \cap_{n:c_n=1}\mathcal V_n}:
+#'     \deqn{\log W(c) =
+#'       \log\sum_{j \in \mathcal V_c} \pi_j
+#'       \exp\{\sum_{n:c_n=1}\log\mathrm{BF}_{n,l_n,j}\},}
+#'     with \eqn{\pi_j} uniform over aligned variants and \eqn{\log W(0)=0}.
+#'   \item Normalise under a uniform prior over the \eqn{2^N} activation
+#'     configurations.
 #'   \item Per-trait marginal: \eqn{P(\mathrm{trait}\,n\,\mathrm{causal}) =
 #'     \sum_{c: c_n = 1} P(c \mid \mathrm{tuple})}.
 #' }
+#'
+#' The \eqn{2^N} activation space is a coherent post hoc model for a candidate
+#' credible-set event. It is especially useful in cross-population fine-mapping,
+#' where a proposed shared causal event may be causal or detectable in only a
+#' subset of populations because of differences in LD, allele frequency, sample
+#' size, or effect size.
+#'
+#' This activation space should be distinguished from the complete coloc-style
+#' sharing space. A complete colocalisation model also allows active traits to
+#' split into distinct causal groups. With inactive traits allowed, this is a
+#' partial-partition space of size Bell(\eqn{N+1}). In other words,
+#' SuSiEx-style activation asks which traits participate in one candidate
+#' event, whereas a complete coloc-style model asks how active traits are
+#' partitioned into one or more causal events.
+#'
+#' For two traits, the SuSiEx-style activation space contains
+#' \eqn{H(0,0)}, \eqn{H(1,0)}, \eqn{H(0,1)}, and \eqn{H(1,1)}. Coloc further
+#' separates the active state \eqn{H(1,1)} into two competing explanations:
+#' H3, where both traits are active but have distinct causal variants, and H4,
+#' where both traits share one causal variant.
+#'
 #' }
 #'
 #' \subsection{Coloc pairwise algorithm}{
@@ -110,7 +138,7 @@
 #'   alone, \code{p2} for trait 2 alone, \code{p12} for shared causal.
 #'   Defaults match \code{coloc::coloc.bf_bf}: \code{p1 = p2 = 1e-4},
 #'   \code{p12 = 5e-6}. Only used when \code{"coloc_pairwise"} is in
-#'   \code{methods}.
+#'   \code{method}.
 #' @param ... Currently ignored.
 #'
 #' @return A list of class \code{"susie_post_outcome_configuration"} with
@@ -119,7 +147,8 @@
 #'   \item{\code{$susiex}}{(when \code{method = "susiex"}) A list of length
 #'     equal to the number of CS tuples considered. Each element has
 #'     components \code{cs_indices} (length-N integer tuple),
-#'     \code{logBF_trait} (length N), \code{configs} (\eqn{2^N \times N}
+#'     \code{logBF_trait} (length-N singleton activation log BF),
+#'     \code{configs} (\eqn{2^N \times N}
 #'     binary matrix), \code{config_prob} (length \eqn{2^N}),
 #'     \code{marginal_prob} (length-N per-trait marginal posterior
 #'     probability of being active across the configuration ensemble),
@@ -323,6 +352,35 @@ enumerate_cs_tuples <- function(views, by, cs_only) {
 # SuSiEx 2^N configuration enumeration.
 # -----------------------------------------------------------------------------
 
+.view_variant_keys <- function(view) {
+  alpha_names <- colnames(view$alpha)
+  lbf_names   <- colnames(view$lbf)
+  if (!is.null(alpha_names) && !is.null(lbf_names) &&
+      !identical(alpha_names, lbf_names)) {
+    stop("Trait '", view$name, "': column names of `alpha` and `lbf` ",
+         "must match for SuSiEx variant-level configuration scoring.")
+  }
+  keys <- if (!is.null(lbf_names)) lbf_names else alpha_names
+  if (is.null(keys)) keys <- paste0(".variant_", seq_len(ncol(view$lbf)))
+  keys
+}
+
+.susiex_config_logbf <- function(config, tuple, views, variant_keys,
+                                 variant_space_size) {
+  active <- which(config == 1L)
+  if (length(active) == 0L) return(0)
+
+  common <- Reduce(intersect, variant_keys[active])
+  if (length(common) == 0L) return(-Inf)
+
+  logbf <- rep(-log(variant_space_size), length(common))
+  for (n in active) {
+    idx <- match(common, variant_keys[[n]])
+    logbf <- logbf + views[[n]]$lbf[tuple[n], idx]
+  }
+  .logsum(logbf)
+}
+
 susiex_configurations <- function(views, by, prob_thresh,
                                   max_traits = 20L) {
   N <- length(views)
@@ -337,6 +395,8 @@ susiex_configurations <- function(views, by, prob_thresh,
   configs <- as.matrix(expand.grid(rep(list(c(0L, 1L)), N)))
   colnames(configs) <- paste0("trait_", seq_len(N))
   trait_names <- vapply(views, function(v) v$name, character(1))
+  variant_keys <- lapply(views, .view_variant_keys)
+  variant_space_size <- length(Reduce(union, variant_keys))
 
   out <- vector("list", length(cs_tuples))
   for (ti in seq_along(cs_tuples)) {
@@ -347,16 +407,31 @@ susiex_configurations <- function(views, by, prob_thresh,
     for (n in seq_len(N)) {
       l_n       <- tuple[n]
       alpha_row <- views[[n]]$alpha[l_n, ]
-      lbf_row   <- views[[n]]$lbf  [l_n, ]
       if (all(alpha_row == 0)) { skip <- TRUE; break }
-      logBF_trait[n] <- sum(alpha_row * lbf_row)   # alpha-weighted SNP avg
+      singleton <- integer(N)
+      singleton[n] <- 1L
+      logBF_trait[n] <- .susiex_config_logbf(
+        config = singleton,
+        tuple = tuple,
+        views = views,
+        variant_keys = variant_keys,
+        variant_space_size = variant_space_size
+      )
     }
     if (skip) {
       out[[ti]] <- NULL
       next
     }
 
-    logBF_conf    <- as.vector(configs %*% logBF_trait)
+    logBF_conf    <- vapply(seq_len(nrow(configs)), function(m) {
+      .susiex_config_logbf(
+        config = configs[m, ],
+        tuple = tuple,
+        views = views,
+        variant_keys = variant_keys,
+        variant_space_size = variant_space_size
+      )
+    }, numeric(1))
     maxlog        <- max(logBF_conf)
     prob_conf     <- exp(logBF_conf - maxlog)
     prob_conf     <- prob_conf / sum(prob_conf)

--- a/R/susie_post_outcome_configuration.R
+++ b/R/susie_post_outcome_configuration.R
@@ -14,9 +14,6 @@
 #     verbatim port of `coloc:::combine.abf` so susieR has no soft
 #     dependency on coloc.
 #
-#   * mvSuSiE CS-level summary: for one multi-output mvsusie/mfsusie fit,
-#     organize native mvSuSiE CS/effect evidence into readable tables.
-#
 # The public function normalises any supported input shape (single fit, list
 # of fits, or a single multi-output fit treated outcome-wise) to a flat list
 # of "trait views", then runs the requested algorithms against that list.
@@ -27,17 +24,15 @@
 
 #' Post-hoc causal-configuration probabilities for one or more SuSiE-class fits
 #'
-#' Runs one of three complementary post-hoc analyses, selected by
+#' Runs one of two complementary post-hoc analyses, selected by
 #' \code{method}: \code{"susiex"} (default) for the SuSiEx \eqn{2^N}
 #' combinatorial enumeration, reporting posterior probabilities over
 #' binary causality patterns across the \eqn{N} input traits;
 #' \code{"coloc_pairwise"} for the coloc pairwise ABF, reporting the
 #' five colocalisation hypothesis posteriors (H0/H1/H2/H3/H4) for every
-#' pair of traits; or \code{"mvsusie"} for CS-level summaries
-#' from one multi-output mvSuSiE fit. To get multiple views, call the
-#' function more than once and combine.
+#' pair of traits. To get both views, call the function twice and combine.
 #'
-#' Three input organizations are supported:
+#' Two input organizations are supported:
 #' \describe{
 #'   \item{\code{by = "fit"}}{Each input fit contributes a single trait view.
 #'     Multi-output fits (\code{mvsusie}, \code{mfsusie}) are kept whole: the
@@ -53,8 +48,6 @@
 #'     reduces to a single index \eqn{l \in 1..L}. Single-output \code{susie}
 #'     fits pass through unchanged. Requires \code{$lbf_variable_outcome} on the
 #'     fit (set \code{attach_lbf_variable_outcome = TRUE} when fitting).}
-#'   \item{\code{method = "mvsusie"}}{One multi-output mvSuSiE fit is used
-#'     directly, and results are summarized at the CS/effect level.}
 #' }
 #'
 #' After SuSiE has been fit, the post-hoc step can answer two related
@@ -116,14 +109,14 @@
 #'   \code{trait_1}, \code{trait_2}, ... are used. If provided, its length must
 #'   match the number of trait views after applying \code{by}.
 #' @param method Character scalar; one of \code{"susiex"} (default),
-#'   \code{"coloc_pairwise"}, or \code{"mvsusie"}. Pick the analysis to run;
-#'   for multiple analyses, call the function more than once.
+#'   or \code{"coloc_pairwise"}. Pick the analysis to run; for both analyses,
+#'   call the function twice.
 #' @param prob_thresh Per-trait marginal threshold for the convenience
 #'   \code{$active} flags in the SuSiEx output. Default \code{0.8}.
-#' @param single_effect_lfsr_cutoff LFSR threshold used to flag mvSuSiE
-#'   outcome-specific CS evidence in the \code{"mvsusie"} summary.
-#'   The LFSR is read from \code{fit$lfsr} at each CS sentinel SNP.
-#'   Default \code{0.05}.
+#' @param single_effect_lfsr_cutoff LFSR threshold used to flag
+#'   outcome-specific CS evidence when \code{method = "susiex"} is applied to
+#'   one multi-output \code{mvsusie} or \code{mfsusie} fit. The LFSR is read
+#'   from \code{fit$lfsr} at each CS sentinel SNP. Default \code{0.05}.
 #' @param cs_only Logical. If \code{TRUE} (default) only enumerate over CSs
 #'   present in each fit's \code{$sets$cs}; if \code{FALSE} loop over all L
 #'   rows of \code{$alpha}. Either way, effects whose entire alpha row is
@@ -146,16 +139,17 @@
 #'     equal to the number of CS tuples considered. Each element has
 #'     components \code{config_probability} (binary trait-activation table
 #'     with a \code{config_prob} column) and \code{activation_summary}
-#'     (CS-level post-hoc activation summary by trait).}
+#'     (CS-level post-hoc activation summary by trait). For one multi-output
+#'     \code{mvsusie} or \code{mfsusie} fit, each CS element instead combines
+#'     native CS summaries (\code{mvsusie_cs_summary},
+#'     \code{mvsusie_config_summary},
+#'     \code{mvsusie_cs_variant_summary}) with SuSiEx interpretation tables
+#'     (\code{susiex_config_probability},
+#'     \code{susiex_activation_summary}).}
 #'   \item{\code{$coloc_pairwise}}{(when \code{method = "coloc_pairwise"})
 #'     A data.frame with one row per (trait1, trait2, l1, l2)
 #'     combination, columns \code{trait1, trait2, l1, l2, hit1, hit2,
 #'     PP.H0, PP.H1, PP.H2, PP.H3, PP.H4}.}
-#'   \item{\code{$mvsusie}}{(when \code{method = "mvsusie"}) Summarizes one
-#'     multi-output \code{mvsusie} or \code{mfsusie} fit by CS, returning
-#'     \code{cs_summary} (CS purity and sentinel), \code{config_summary}
-#'     (outcome log BF, sentinel variant/LFSR, cutoff flag), and
-#'     \code{cs_variant_summary} (CS variant PIP and outcome-specific LFSR).}
 #' }
 #' Pretty-print with \code{summary(out)}.
 #'
@@ -170,8 +164,7 @@ susie_post_outcome_configuration <- function(input,
                                              by          = c("fit", "outcome"),
                                              outcome_names = NULL,
                                              method      = c("susiex",
-                                             "coloc_pairwise",
-                                             "mvsusie"),
+                                             "coloc_pairwise"),
                                              prob_thresh = 0.8,
                                              single_effect_lfsr_cutoff = 0.05,
                                              cs_only     = TRUE,
@@ -179,6 +172,7 @@ susie_post_outcome_configuration <- function(input,
                                              p2          = 1e-4,
                                              p12         = 5e-6,
                                              ...) {
+  by_missing <- missing(by)
   by     <- match.arg(by)
   method <- match.arg(method)
 
@@ -204,13 +198,17 @@ susie_post_outcome_configuration <- function(input,
   }
 
   out <- list()
-  if (identical(method, "mvsusie")) {
-    out$mvsusie <- mvsusie_cs_summary(input,
-                                      outcome_names = outcome_names,
-                                      single_effect_lfsr_cutoff =
-                                        single_effect_lfsr_cutoff,
-                                      cs_only       = cs_only)
-    if (is.null(out$mvsusie)) return(NULL)
+  if (identical(method, "susiex") &&
+      is_single_multi_output_fit_input(input) &&
+      (by_missing || identical(by, "outcome"))) {
+    out$susiex <- multi_output_susiex_summary(
+      input,
+      outcome_names = outcome_names,
+      single_effect_lfsr_cutoff = single_effect_lfsr_cutoff,
+      prob_thresh = prob_thresh,
+      cs_only = cs_only
+    )
+    if (is.null(out$susiex)) return(NULL)
   } else {
     views <- normalise_to_views(input, by = by)
     if (!is.null(outcome_names)) {
@@ -252,6 +250,15 @@ susie_post_outcome_configuration <- function(input,
 
 is_susie_fit <- function(x) {
   inherits(x, "susie") || inherits(x, "mvsusie") || inherits(x, "mfsusie")
+}
+
+is_multi_output_fit <- function(x) {
+  inherits(x, "mvsusie") || inherits(x, "mfsusie")
+}
+
+is_single_multi_output_fit_input <- function(input) {
+  is_multi_output_fit(input) ||
+    (is.list(input) && length(input) == 1L && is_multi_output_fit(input[[1L]]))
 }
 
 normalise_to_views <- function(input, by) {
@@ -313,7 +320,7 @@ expand_one_fit <- function(fit, base_name, by) {
 
   # by = "outcome": multi-output fits fan out; single-output fits pass
   # through as one view.
-  if (inherits(fit, "mvsusie") || inherits(fit, "mfsusie")) {
+  if (is_multi_output_fit(fit)) {
     if (is.null(fit$lbf_variable_outcome)) {
       stop("Fit '", base_name, "': `by = \"outcome\"` requires `$lbf_variable_outcome` ",
            "(an L x J x R or L x J x M array) on the fit. ",
@@ -326,10 +333,17 @@ expand_one_fit <- function(fit, base_name, by) {
     if (is.null(out_names)) out_names <- paste0("outcome_", seq_len(R))
     views <- vector("list", R)
     for (r in seq_len(R)) {
+      lbf_r <- fit$lbf_variable_outcome[, , r, drop = FALSE]
+      dim(lbf_r) <- dim(fit$lbf_variable_outcome)[1:2]
+      lbf_dimnames <- dimnames(fit$lbf_variable_outcome)
+      if (!is.null(lbf_dimnames) &&
+          (!is.null(lbf_dimnames[[1L]]) || !is.null(lbf_dimnames[[2L]]))) {
+        dimnames(lbf_r) <- lbf_dimnames[1:2]
+      }
       views[[r]] <- make_view(
         name    = paste0(base_name, "_", out_names[r]),
         alpha   = fit$alpha,
-        lbf     = fit$lbf_variable_outcome[, , r, drop = TRUE],
+        lbf     = lbf_r,
         sets_cs = fit$sets$cs
       )
     }
@@ -577,12 +591,10 @@ susiex_configurations <- function(views, by, prob_thresh,
 # -----------------------------------------------------------------------------
 
 as_single_mvsusie_fit <- function(input) {
-  is_mv <- function(x) inherits(x, "mvsusie") || inherits(x, "mfsusie")
-  if (is_mv(input)) return(input)
-  if (is.list(input) && length(input) == 1L && is_mv(input[[1L]])) {
-    return(input[[1L]])
+  if (is_single_multi_output_fit_input(input)) {
+    return(if (is_multi_output_fit(input)) input else input[[1L]])
   }
-  stop("method = \"mvsusie\" requires one multi-output fit of class ",
+  stop("multi-output SuSiE summary requires one fit of class ",
        "`mvsusie` or `mfsusie`.")
 }
 
@@ -611,14 +623,14 @@ mvsusie_lbf_outcome <- function(fit) {
   }
 
   if (is.null(fit$alpha) || is.null(fit$lbf_variable_outcome)) {
-    stop("method = \"mvsusie\" requires `$lbf_outcome`, or both `$alpha` ",
+    stop("multi-output SuSiE summary requires `$lbf_outcome`, or both `$alpha` ",
          "and `$lbf_variable_outcome` to compute CS-level log Bayes factors.")
   }
   alpha <- fit$alpha
   arr <- fit$lbf_variable_outcome
   if (!is.matrix(alpha) || length(dim(arr)) != 3L ||
       nrow(alpha) != dim(arr)[1L] || ncol(alpha) != dim(arr)[2L]) {
-    stop("For method = \"mvsusie\", `$alpha` must be L x J and ",
+    stop("For multi-output SuSiE summary, `$alpha` must be L x J and ",
          "`$lbf_variable_outcome` must be L x J x R with matching L and J.")
   }
 
@@ -707,13 +719,54 @@ mvsusie_cs_purity <- function(fit, label, idx) {
   as.numeric(purity[pos, 1L])
 }
 
+multi_output_susiex_summary <- function(input, outcome_names = NULL,
+                                        single_effect_lfsr_cutoff = 0.05,
+                                        prob_thresh = 0.8,
+                                        cs_only) {
+  fit <- as_single_mvsusie_fit(input)
+  native <- mvsusie_cs_summary(
+    fit,
+    outcome_names = outcome_names,
+    single_effect_lfsr_cutoff = single_effect_lfsr_cutoff,
+    cs_only = cs_only
+  )
+  if (is.null(native)) return(NULL)
+
+  views <- expand_one_fit(fit, base_name = "trait", by = "outcome")
+  trait_names <- native[[1L]]$mvsusie_config_summary$outcome
+  if (length(trait_names) != length(views)) {
+    stop("Internal error: multi-output CS summary and outcome views disagree.")
+  }
+  for (r in seq_along(views)) {
+    views[[r]]$name <- trait_names[r]
+  }
+
+  sx <- susiex_configurations(views, by = "outcome",
+                              prob_thresh = prob_thresh)
+  sx_names <- vapply(sx, function(x) {
+    raw <- .susiex_raw(x)
+    if (is.list(raw) && !is.null(raw$cs_labels)) raw$cs_labels[[1L]]
+    else NA_character_
+  }, character(1))
+
+  for (nm in names(native)) {
+    pos <- match(nm, sx_names)
+    if (!is.na(pos)) {
+      native[[nm]]$susiex_config_probability <- sx[[pos]]$config_probability
+      native[[nm]]$susiex_activation_summary <- sx[[pos]]$activation_summary
+      attr(native[[nm]], "raw") <- attr(sx[[pos]], "raw", exact = TRUE)
+    }
+  }
+  native
+}
+
 mvsusie_cs_summary <- function(input, outcome_names = NULL,
                                single_effect_lfsr_cutoff = 0.05,
                                cs_only) {
   fit <- as_single_mvsusie_fit(input)
   logBF_mat <- mvsusie_lbf_outcome(fit)
   if (nrow(logBF_mat) != nrow(fit$alpha)) {
-    stop("For method = \"mvsusie\", `$lbf_outcome` must have one row per ",
+    stop("For multi-output SuSiE summary, `$lbf_outcome` must have one row per ",
          "single effect in `$alpha`.")
   }
 
@@ -813,13 +866,14 @@ mvsusie_cs_summary <- function(input, outcome_names = NULL,
       stringsAsFactors = FALSE,
       check.names = FALSE
     )
-    out[[i]] <- list(cs_summary = cs_summary,
-                     config_summary = config_summary,
-                     cs_variant_summary = cs_variant_summary)
+    out[[i]] <- list(mvsusie_cs_summary = cs_summary,
+                     mvsusie_config_summary = config_summary,
+                     mvsusie_cs_variant_summary = cs_variant_summary)
   }
 
   out <- out[!vapply(out, is.null, logical(1))]
-  names(out) <- vapply(out, function(x) x$cs_summary$cs[[1]], character(1))
+  names(out) <- vapply(out, function(x) x$mvsusie_cs_summary$cs[[1]],
+                       character(1))
   out
 }
 

--- a/R/susie_post_outcome_configuration.R
+++ b/R/susie_post_outcome_configuration.R
@@ -153,9 +153,9 @@
 #'     PP.H0, PP.H1, PP.H2, PP.H3, PP.H4}.}
 #'   \item{\code{$mvsusie}}{(when \code{method = "mvsusie"}) Summarizes one
 #'     multi-output \code{mvsusie} or \code{mfsusie} fit by CS, returning
-#'     \code{cs_summary}, \code{config_summary} (outcome log BF, sentinel
-#'     LFSR, cutoff flag), and \code{cs_variant_summary} (CS variant PIP and
-#'     outcome-specific LFSR).}
+#'     \code{cs_summary} (CS purity and sentinel), \code{config_summary}
+#'     (outcome log BF, sentinel variant/LFSR, cutoff flag), and
+#'     \code{cs_variant_summary} (CS variant PIP and outcome-specific LFSR).}
 #' }
 #' Pretty-print with \code{summary(out)}.
 #'
@@ -685,6 +685,28 @@ mvsusie_cs_hit <- function(fit, label, idx, variable_names) {
        variant_idx = member_idx, pips = pip)
 }
 
+mvsusie_cs_purity <- function(fit, label, idx) {
+  purity <- fit$sets$purity
+  if (is.null(purity)) return(NA_real_)
+
+  pos <- if (!is.null(rownames(purity))) {
+    match(label, rownames(purity))
+  } else {
+    NA_integer_
+  }
+  if (is.na(pos) && !is.null(names(fit$sets$cs))) {
+    pos <- match(label, names(fit$sets$cs))
+  }
+  if (is.na(pos)) {
+    cs_idx <- attr(fit$sets$cs, "cs_idx")
+    if (!is.null(cs_idx)) pos <- match(idx, cs_idx)
+  }
+  if (is.na(pos) || pos < 1L || pos > nrow(purity) || ncol(purity) < 1L) {
+    return(NA_real_)
+  }
+  as.numeric(purity[pos, 1L])
+}
+
 mvsusie_cs_summary <- function(input, outcome_names = NULL,
                                single_effect_lfsr_cutoff = 0.05,
                                cs_only) {
@@ -750,12 +772,12 @@ mvsusie_cs_summary <- function(input, outcome_names = NULL,
 
     cs_summary <- data.frame(
       cs            = cs$labels[i],
-      single_effect = l,
-      n_cs          = hit$n_cs,
+      n_variant     = hit$n_cs,
+      purity        = mvsusie_cs_purity(fit, label = cs$labels[i], idx = l),
       hit           = hit$hit,
       maxPIP        = hit$maxPIP,
       lbf           = effect_lbf[l],
-      n_lfsr_pass   = sum(sentinel_lfsr_pass, na.rm = TRUE),
+      n_lfsr_outcome = sum(sentinel_lfsr_pass, na.rm = TRUE),
       stringsAsFactors = FALSE,
       check.names = FALSE
     )
@@ -784,8 +806,10 @@ mvsusie_cs_summary <- function(input, outcome_names = NULL,
     config_summary <- data.frame(
       outcome = trait_names,
       lbf_outcome = as.numeric(logBF_mat[l, ]),
+      sentinel_variant = rep(hit$hit, R),
       sentinel_lfsr = sentinel_lfsr,
       lfsr_pass = sentinel_lfsr_pass,
+      lfsr_cutoff = rep(single_effect_lfsr_cutoff, R),
       stringsAsFactors = FALSE,
       check.names = FALSE
     )

--- a/R/susie_post_outcome_configuration.R
+++ b/R/susie_post_outcome_configuration.R
@@ -136,13 +136,15 @@
 #' components, depending on \code{method}:
 #' \describe{
 #'   \item{\code{$susiex}}{(when \code{method = "susiex"}) A list of length
-#'     equal to the number of CS tuples considered. Each element has
+#'     equal to the number of CS tuples considered, named \code{config_1},
+#'     \code{config_2}, etc. Each element has
 #'     components \code{config_probability} (binary trait-activation table
 #'     with a \code{config_prob} column) and \code{config_summary}
 #'     (CS-level post-hoc activation summary, with one row per trait). For one
-#'     multi-output \code{mvsusie} or \code{mfsusie} fit, the return also has
-#'     \code{$mvsusie}, a native summary list with \code{cs_summary},
-#'     \code{config_summary}, and \code{cs_variant_summary}.}
+#'     multi-output \code{mvsusie} or \code{mfsusie} fit, both \code{$susiex}
+#'     and \code{$mvsusie} are named by CS label, e.g. \code{L1}; each
+#'     \code{$mvsusie} element has \code{cs_summary}, \code{config_summary},
+#'     and \code{cs_variant_summary}.}
 #'   \item{\code{$coloc_pairwise}}{(when \code{method = "coloc_pairwise"})
 #'     A data.frame with one row per (trait1, trait2, l1, l2)
 #'     combination, columns \code{trait1, trait2, l1, l2, hit1, hit2,
@@ -467,7 +469,9 @@ enumerate_cs_tuples <- function(views, by, cs_only) {
 }
 
 susiex_configurations <- function(views, by, prob_thresh,
-                                  max_traits = 20L) {
+                                  max_traits = 20L,
+                                  name_by = c("config", "cs")) {
+  name_by <- match.arg(name_by)
   N <- length(views)
   if (N > max_traits) {
     stop("susiex: N = ", N, " traits exceeds the safety ceiling (",
@@ -537,11 +541,13 @@ susiex_configurations <- function(views, by, prob_thresh,
     )
   }
 
-  .organize_susiex_output(out[!vapply(out, is.null, logical(1))])
+  .organize_susiex_output(out[!vapply(out, is.null, logical(1))],
+                          name_by = name_by)
 }
 
-.organize_susiex_output <- function(susiex) {
-  lapply(susiex, function(tup) {
+.organize_susiex_output <- function(susiex, name_by = c("config", "cs")) {
+  name_by <- match.arg(name_by)
+  out <- lapply(susiex, function(tup) {
     if (!is.list(tup)) return(tup)
 
     trait_names <- names(tup$cs_indices)
@@ -582,6 +588,29 @@ susiex_configurations <- function(views, by, prob_thresh,
     attr(out, "raw") <- tup
     out
   })
+  if (length(out) == 0L) return(out)
+  out_names <- if (identical(name_by, "config")) {
+    paste0("config_", seq_len(length(out)))
+  } else {
+    vapply(out, .susiex_tuple_name, character(1))
+  }
+  out_names[!nzchar(out_names)] <- paste0("config_", which(!nzchar(out_names)))
+  names(out) <- make.unique(out_names, sep = "_")
+  out
+}
+
+.susiex_tuple_name <- function(tup) {
+  raw <- .susiex_raw(tup)
+  if (!is.list(raw)) return("")
+  labels <- raw$cs_labels
+  if (is.null(labels) && !is.null(raw$cs_indices)) {
+    labels <- paste0("L", raw$cs_indices)
+  }
+  labels <- as.character(labels)
+  labels <- labels[!is.na(labels) & nzchar(labels)]
+  if (length(labels) == 0L) return("")
+  if (length(unique(labels)) == 1L) return(labels[[1L]])
+  paste(labels, collapse = "_")
 }
 
 
@@ -732,7 +761,7 @@ multi_output_susiex_summary <- function(input, outcome_names = NULL,
   if (is.null(native)) return(NULL)
 
   views <- expand_one_fit(fit, base_name = "trait", by = "outcome")
-  trait_names <- native[[1L]]$mvsusie_config_summary$outcome
+  trait_names <- native[[1L]]$config_summary$outcome
   if (length(trait_names) != length(views)) {
     stop("Internal error: multi-output CS summary and outcome views disagree.")
   }
@@ -741,37 +770,11 @@ multi_output_susiex_summary <- function(input, outcome_names = NULL,
   }
 
   sx <- susiex_configurations(views, by = "outcome",
-                              prob_thresh = prob_thresh)
-  sx_names <- vapply(sx, function(x) {
-    raw <- .susiex_raw(x)
-    if (is.list(raw) && !is.null(raw$cs_labels)) raw$cs_labels[[1L]]
-    else NA_character_
-  }, character(1))
-  names(sx) <- sx_names
+                              prob_thresh = prob_thresh,
+                              name_by = "cs")
 
-  list(mvsusie = flatten_mvsusie_summary(native),
-       susiex = sx[!is.na(names(sx))])
-}
-
-flatten_mvsusie_summary <- function(native) {
-  add_cs <- function(df, cs) {
-    data.frame(cs = rep(cs, nrow(df)), df,
-               check.names = FALSE, row.names = NULL)
-  }
-  cs <- do.call(rbind, lapply(native, `[[`, "mvsusie_cs_summary"))
-  config <- do.call(rbind, Map(function(x, nm) {
-    add_cs(x$mvsusie_config_summary, nm)
-  }, native, names(native)))
-  variants <- do.call(rbind, Map(function(x, nm) {
-    add_cs(x$mvsusie_cs_variant_summary, nm)
-  }, native, names(native)))
-  rownames(cs) <- rownames(config) <- rownames(variants) <- NULL
-
-  list(
-    cs_summary = cs,
-    config_summary = config,
-    cs_variant_summary = variants
-  )
+  list(mvsusie = native,
+       susiex = sx)
 }
 
 mvsusie_cs_summary <- function(input, outcome_names = NULL,
@@ -880,13 +883,13 @@ mvsusie_cs_summary <- function(input, outcome_names = NULL,
       stringsAsFactors = FALSE,
       check.names = FALSE
     )
-    out[[i]] <- list(mvsusie_cs_summary = cs_summary,
-                     mvsusie_config_summary = config_summary,
-                     mvsusie_cs_variant_summary = cs_variant_summary)
+    out[[i]] <- list(cs_summary = cs_summary,
+                     config_summary = config_summary,
+                     cs_variant_summary = cs_variant_summary)
   }
 
   out <- out[!vapply(out, is.null, logical(1))]
-  names(out) <- vapply(out, function(x) x$mvsusie_cs_summary$cs[[1]],
+  names(out) <- vapply(out, function(x) x$cs_summary$cs[[1]],
                        character(1))
   out
 }

--- a/R/susie_post_outcome_configuration.R
+++ b/R/susie_post_outcome_configuration.R
@@ -180,8 +180,18 @@ susie_post_outcome_configuration <- function(input,
     }
   }
 
-  views <- normalise_to_views(input, by = by, cs_only = cs_only,
-                              outcome_names = outcome_names)
+  views <- normalise_to_views(input, by = by, cs_only = cs_only)
+  if (!is.null(outcome_names)) {
+    if (!is.character(outcome_names) ||
+        length(outcome_names) != length(views) ||
+        anyNA(outcome_names) || any(!nzchar(outcome_names))) {
+      stop("`outcome_names` must be a non-empty character vector with ",
+           "length equal to the number of trait views.")
+    }
+    for (k in seq_along(views)) {
+      views[[k]]$name <- outcome_names[k]
+    }
+  }
 
   out <- list()
   if (identical(method, "susiex")) {
@@ -209,7 +219,7 @@ is_susie_fit <- function(x) {
   inherits(x, "susie") || inherits(x, "mvsusie") || inherits(x, "mfsusie")
 }
 
-normalise_to_views <- function(input, by, cs_only, outcome_names = NULL) {
+normalise_to_views <- function(input, by, cs_only) {
   fits <- if (is_susie_fit(input)) list(input) else as.list(input)
 
   if (length(fits) == 0L) {
@@ -236,17 +246,6 @@ normalise_to_views <- function(input, by, cs_only, outcome_names = NULL) {
   views <- vector("list", 0)
   for (k in seq_along(fits)) {
     views <- c(views, expand_one_fit(fits[[k]], raw_names[k], by = by))
-  }
-  if (!is.null(outcome_names)) {
-    if (!is.character(outcome_names) ||
-        length(outcome_names) != length(views) ||
-        anyNA(outcome_names) || any(!nzchar(outcome_names))) {
-      stop("`outcome_names` must be a non-empty character vector with ",
-           "length equal to the number of trait views.")
-    }
-    for (k in seq_along(views)) {
-      views[[k]]$name <- outcome_names[k]
-    }
   }
   views
 }

--- a/R/susie_post_outcome_configuration.R
+++ b/R/susie_post_outcome_configuration.R
@@ -130,10 +130,13 @@
 #' \describe{
 #'   \item{\code{$susiex}}{(when \code{method = "susiex"}) A list of length
 #'     equal to the number of CS tuples considered. Each element has
-#'     components \code{cs_indices} (length-N integer tuple),
+#'     components \code{config_probability} (binary trait-activation table
+#'     with a \code{config_prob} column), \code{activation_summary}
+#'     (CS-level post-hoc activation summary by trait), \code{cs_indices}
+#'     (length-N integer tuple),
 #'     \code{logBF_trait} (length-N singleton activation log BF),
-#'     \code{configs} (\eqn{2^N \times N}
-#'     binary matrix), \code{config_prob} (length \eqn{2^N}),
+#'     \code{configs} (\eqn{2^N \times N} binary matrix),
+#'     \code{config_prob} (length \eqn{2^N}),
 #'     \code{marginal_prob} (length-N per-trait marginal posterior
 #'     probability of being active across the configuration ensemble),
 #'     and \code{active} (logical, \code{marginal_prob >= prob_thresh}).}
@@ -434,18 +437,53 @@ susiex_configurations <- function(views, by, prob_thresh,
     prob_conf     <- exp(logBF_conf - maxlog)
     prob_conf     <- prob_conf / sum(prob_conf)
     marginal_prob <- as.vector(crossprod(configs, prob_conf))
+    names(logBF_trait) <- names(marginal_prob) <- trait_names
+    active <- setNames(marginal_prob >= prob_thresh, trait_names)
 
     out[[ti]] <- list(
-      cs_indices    = setNames(as.integer(tuple),  trait_names),
-      logBF_trait   = setNames(logBF_trait,        trait_names),
+      cs_indices    = setNames(as.integer(tuple), trait_names),
+      logBF_trait   = logBF_trait,
       configs       = configs,
       config_prob   = prob_conf,
-      marginal_prob = setNames(marginal_prob,      trait_names),
-      active        = setNames(marginal_prob >= prob_thresh, trait_names)
+      marginal_prob = marginal_prob,
+      active        = active
     )
   }
 
-  out[!vapply(out, is.null, logical(1))]
+  .organize_susiex_output(out[!vapply(out, is.null, logical(1))])
+}
+
+.organize_susiex_output <- function(susiex) {
+  lapply(susiex, function(tup) {
+    if (!is.list(tup)) return(tup)
+
+    config_probability <- if (is.matrix(tup$configs) &&
+                              !is.null(tup$config_prob) &&
+                              nrow(tup$configs) == length(tup$config_prob)) {
+      config_probability <- as.data.frame(tup$configs)
+      config_probability$config_prob <- tup$config_prob
+      config_probability
+    } else NULL
+
+    trait_names <- names(tup$cs_indices)
+    if (is.null(trait_names) || any(!nzchar(trait_names))) {
+      trait_names <- names(tup$marginal_prob)
+    }
+    activation_summary <- if (!is.null(trait_names) &&
+                              length(trait_names) > 0L) {
+      vals <- rbind(
+        cs_indices    = as.character(tup$cs_indices[trait_names]),
+        logBF_trait   = as.character(tup$logBF_trait[trait_names]),
+        posthoc_prob  = as.character(tup$marginal_prob[trait_names]),
+        active        = as.character(tup$active[trait_names])
+      )
+      colnames(vals) <- trait_names
+      as.data.frame(vals, check.names = FALSE, stringsAsFactors = FALSE)
+    } else NULL
+
+    c(list(config_probability = config_probability,
+           activation_summary = activation_summary), tup)
+  })
 }
 
 # -----------------------------------------------------------------------------

--- a/R/susie_post_outcome_configuration.R
+++ b/R/susie_post_outcome_configuration.R
@@ -116,8 +116,9 @@
 #' @param cs_only Logical. If \code{TRUE} (default) only enumerate over CSs
 #'   present in each fit's \code{$sets$cs}; if \code{FALSE} loop over all L
 #'   rows of \code{$alpha}. Either way, effects whose entire alpha row is
-#'   zero are skipped. When \code{TRUE}, every fit must carry a non-null
-#'   \code{$sets$cs} or the function errors.
+#'   zero are skipped. When \code{TRUE}, trait views without credible sets
+#'   are skipped with a warning; if fewer than two trait views remain, the
+#'   function returns \code{NULL}.
 #' @param p1,p2,p12 Coloc per-SNP causal priors: \code{p1} for trait 1
 #'   alone, \code{p2} for trait 2 alone, \code{p12} for shared causal.
 #'   Defaults match \code{coloc::coloc.bf_bf}: \code{p1 = p2 = 1e-4},
@@ -125,8 +126,10 @@
 #'   \code{method}.
 #' @param ... Currently ignored.
 #'
-#' @return A list of class \code{"susie_post_outcome_configuration"} with
-#' exactly one of the following components, depending on \code{method}:
+#' @return \code{NULL} if fewer than two trait views are available for
+#' post-hoc analysis; otherwise a list of class
+#' \code{"susie_post_outcome_configuration"} with exactly one of the following
+#' components, depending on \code{method}:
 #' \describe{
 #'   \item{\code{$susiex}}{(when \code{method = "susiex"}) A list of length
 #'     equal to the number of CS tuples considered. Each element has
@@ -176,7 +179,7 @@ susie_post_outcome_configuration <- function(input,
     }
   }
 
-  views <- normalise_to_views(input, by = by, cs_only = cs_only)
+  views <- normalise_to_views(input, by = by)
   if (!is.null(outcome_names)) {
     if (!is.character(outcome_names) ||
         length(outcome_names) != length(views) ||
@@ -188,6 +191,8 @@ susie_post_outcome_configuration <- function(input,
       views[[k]]$name <- outcome_names[k]
     }
   }
+  views <- filter_views_for_posthoc(views, cs_only = cs_only)
+  if (is.null(views)) return(NULL)
 
   out <- list()
   if (identical(method, "susiex")) {
@@ -215,7 +220,7 @@ is_susie_fit <- function(x) {
   inherits(x, "susie") || inherits(x, "mvsusie") || inherits(x, "mfsusie")
 }
 
-normalise_to_views <- function(input, by, cs_only) {
+normalise_to_views <- function(input, by) {
   fits <- if (is_susie_fit(input)) list(input) else as.list(input)
 
   if (length(fits) == 0L) {
@@ -227,11 +232,6 @@ normalise_to_views <- function(input, by, cs_only) {
            " of `input` is not a SuSiE-class fit (`susie`, `mvsusie`, or ",
            "`mfsusie`).")
     }
-    if (cs_only && is.null(fits[[k]]$sets$cs)) {
-      stop("Fit ", k, ": `cs_only = TRUE` requires `$sets$cs` to be present. ",
-           "Either pass `cs_only = FALSE` or attach a credible-set list via ",
-           "susie_get_cs() before calling.")
-    }
   }
 
   raw_names <- names(fits)
@@ -242,6 +242,27 @@ normalise_to_views <- function(input, by, cs_only) {
   views <- vector("list", 0)
   for (k in seq_along(fits)) {
     views <- c(views, expand_one_fit(fits[[k]], raw_names[k], by = by))
+  }
+  views
+}
+
+filter_views_for_posthoc <- function(views, cs_only) {
+  if (cs_only) {
+    has_cs <- lengths(lapply(views, view_cs_indices, cs_only = TRUE)) > 0L
+    if (any(!has_cs)) {
+      warning("Skipping trait view(s) with no credible sets for post-hoc ",
+              "analysis: ", paste(vapply(views[!has_cs], function(v) v$name,
+                                          character(1)), collapse = ", "),
+              call. = FALSE)
+    }
+    views <- views[has_cs]
+  }
+
+  if (length(views) < 2L) {
+    message("Fewer than two trait views ",
+            if (cs_only) "with credible sets " else "",
+            "for post-hoc outcome configuration analysis; returning NULL.")
+    return(NULL)
   }
   views
 }
@@ -313,6 +334,10 @@ make_view <- function(name, alpha, lbf, sets_cs) {
 view_cs_indices <- function(view, cs_only) {
   L_n <- nrow(view$alpha)
   if (!cs_only) return(seq_len(L_n))
+  if (is.null(view$sets_cs) ||
+      (length(view$sets_cs) == 0L && is.null(attr(view$sets_cs, "cs_idx")))) {
+    return(integer(0))
+  }
 
   idx <- attr(view$sets_cs, "cs_idx")
   if (is.null(idx)) {
@@ -324,6 +349,25 @@ view_cs_indices <- function(view, cs_only) {
     }
   }
   idx[idx >= 1L & idx <= L_n]
+}
+
+view_cs_label <- function(view, idx) {
+  target <- paste0("L", idx)
+  cs <- view$sets_cs
+  if (is.null(cs) || is.na(idx)) return(target)
+
+  cs_names <- names(cs)
+  if (is.null(cs_names)) return(target)
+
+  cs_idx <- attr(cs, "cs_idx")
+  if (!is.null(cs_idx)) {
+    pos <- match(idx, cs_idx)
+    if (!is.na(pos) && pos <= length(cs_names) && nzchar(cs_names[pos])) {
+      return(cs_names[pos])
+    }
+  }
+
+  target
 }
 
 # Returns a list of length-N integer tuples (one CS index per view).
@@ -435,6 +479,9 @@ susiex_configurations <- function(views, by, prob_thresh,
 
     out[[ti]] <- list(
       cs_indices    = setNames(as.integer(tuple), trait_names),
+      cs_labels     = setNames(vapply(seq_len(N), function(n) {
+        view_cs_label(views[[n]], tuple[n])
+      }, character(1)), trait_names),
       logBF_trait   = logBF_trait,
       configs       = configs,
       config_prob   = prob_conf,
@@ -468,8 +515,13 @@ susiex_configurations <- function(views, by, prob_thresh,
 
     activation_summary <- if (!is.null(trait_names) &&
                               length(trait_names) > 0L) {
+      cs_display <- if (!is.null(tup$cs_labels)) {
+        tup$cs_labels[trait_names]
+      } else {
+        paste0("L", tup$cs_indices[trait_names])
+      }
       vals <- rbind(
-        cs_indices    = as.character(tup$cs_indices[trait_names]),
+        cs_indices    = as.character(cs_display),
         logBF_trait   = as.character(tup$logBF_trait[trait_names]),
         posthoc_prob  = as.character(tup$marginal_prob[trait_names]),
         active        = as.character(tup$active[trait_names])

--- a/R/susie_post_outcome_configuration.R
+++ b/R/susie_post_outcome_configuration.R
@@ -131,15 +131,8 @@
 #'   \item{\code{$susiex}}{(when \code{method = "susiex"}) A list of length
 #'     equal to the number of CS tuples considered. Each element has
 #'     components \code{config_probability} (binary trait-activation table
-#'     with a \code{config_prob} column), \code{activation_summary}
-#'     (CS-level post-hoc activation summary by trait), \code{cs_indices}
-#'     (length-N integer tuple),
-#'     \code{logBF_trait} (length-N singleton activation log BF),
-#'     \code{configs} (\eqn{2^N \times N} binary matrix),
-#'     \code{config_prob} (length \eqn{2^N}),
-#'     \code{marginal_prob} (length-N per-trait marginal posterior
-#'     probability of being active across the configuration ensemble),
-#'     and \code{active} (logical, \code{marginal_prob >= prob_thresh}).}
+#'     with a \code{config_prob} column) and \code{activation_summary}
+#'     (CS-level post-hoc activation summary by trait).}
 #'   \item{\code{$coloc_pairwise}}{(when \code{method = "coloc_pairwise"})
 #'     A data.frame with one row per (trait1, trait2, l1, l2)
 #'     combination, columns \code{trait1, trait2, l1, l2, hit1, hit2,
@@ -457,18 +450,22 @@ susiex_configurations <- function(views, by, prob_thresh,
   lapply(susiex, function(tup) {
     if (!is.list(tup)) return(tup)
 
-    config_probability <- if (is.matrix(tup$configs) &&
-                              !is.null(tup$config_prob) &&
-                              nrow(tup$configs) == length(tup$config_prob)) {
-      config_probability <- as.data.frame(tup$configs)
-      config_probability$config_prob <- tup$config_prob
-      config_probability
-    } else NULL
-
     trait_names <- names(tup$cs_indices)
     if (is.null(trait_names) || any(!nzchar(trait_names))) {
       trait_names <- names(tup$marginal_prob)
     }
+
+    config_probability <- if (is.matrix(tup$configs) &&
+                              !is.null(tup$config_prob) &&
+                              nrow(tup$configs) == length(tup$config_prob)) {
+      config_probability <- as.data.frame(tup$configs)
+      if (!is.null(trait_names) && length(trait_names) == ncol(tup$configs)) {
+        colnames(config_probability) <- trait_names
+      }
+      config_probability$config_prob <- tup$config_prob
+      config_probability
+    } else NULL
+
     activation_summary <- if (!is.null(trait_names) &&
                               length(trait_names) > 0L) {
       vals <- rbind(
@@ -481,8 +478,10 @@ susiex_configurations <- function(views, by, prob_thresh,
       as.data.frame(vals, check.names = FALSE, stringsAsFactors = FALSE)
     } else NULL
 
-    c(list(config_probability = config_probability,
-           activation_summary = activation_summary), tup)
+    out <- list(config_probability = config_probability,
+                activation_summary = activation_summary)
+    attr(out, "raw") <- tup
+    out
   })
 }
 
@@ -751,8 +750,9 @@ summary.susie_post_outcome_configuration <- function(
   # Pull the union of trait names across all tuples (some tuples might be
   # malformed and missing fields; we just skip those).
   trait_names_all <- unique(unlist(lapply(susiex, function(tup) {
-    if (is.list(tup) && !is.null(tup$marginal_prob)) {
-      names(tup$marginal_prob)
+    raw <- .susiex_raw(tup)
+    if (is.list(raw) && !is.null(raw$marginal_prob)) {
+      names(raw$marginal_prob)
     } else character(0)
   })))
   if (length(trait_names_all) == 0L) {
@@ -766,25 +766,26 @@ summary.susie_post_outcome_configuration <- function(
   names(trait_cols) <- trait_names_all   # raw -> column-name mapping
 
   rows <- lapply(susiex, function(tup) {
-    if (!is.list(tup) || is.null(tup$marginal_prob) ||
-        is.null(tup$config_prob) || is.null(tup$configs)) {
+    raw <- .susiex_raw(tup)
+    if (!is.list(raw) || is.null(raw$marginal_prob) ||
+        is.null(raw$config_prob) || is.null(raw$configs)) {
       return(NULL)
     }
-    mp <- tup$marginal_prob
+    mp <- raw$marginal_prob
     if (signal_only) {
       # Re-derive active using current prob_thresh (don't trust the stored
       # active flag, which was computed against the call-time threshold).
       if (!any(is.finite(mp) & mp >= prob_thresh)) return(NULL)
     }
-    cp <- tup$config_prob
+    cp <- raw$config_prob
     if (length(cp) == 0L || !all(is.finite(cp))) return(NULL)
     top_idx <- which.max(cp)
-    cfg     <- tup$configs
+    cfg     <- raw$configs
     top_pat <- if (is.matrix(cfg) && nrow(cfg) >= top_idx) {
       paste(cfg[top_idx, ], collapse = "")
     } else NA_character_
-    cs_idx_str <- if (!is.null(tup$cs_indices)) {
-      paste0("(", paste(tup$cs_indices, collapse = ","), ")")
+    cs_idx_str <- if (!is.null(raw$cs_indices)) {
+      paste0("(", paste(raw$cs_indices, collapse = ","), ")")
     } else NA_character_
 
     out <- data.frame(tuple = cs_idx_str, stringsAsFactors = FALSE)
@@ -804,6 +805,11 @@ summary.susie_post_outcome_configuration <- function(
   df <- do.call(rbind, rows)
   rownames(df) <- NULL
   list(df = df, n_total = n_total, n_kept = nrow(df))
+}
+
+.susiex_raw <- function(tup) {
+  raw <- attr(tup, "raw", exact = TRUE)
+  if (is.list(raw)) raw else tup
 }
 
 # Annotate the coloc data.frame with verdict + dominant PP, and optionally

--- a/R/susie_post_outcome_configuration.R
+++ b/R/susie_post_outcome_configuration.R
@@ -138,14 +138,11 @@
 #'   \item{\code{$susiex}}{(when \code{method = "susiex"}) A list of length
 #'     equal to the number of CS tuples considered. Each element has
 #'     components \code{config_probability} (binary trait-activation table
-#'     with a \code{config_prob} column) and \code{activation_summary}
-#'     (CS-level post-hoc activation summary by trait). For one multi-output
-#'     \code{mvsusie} or \code{mfsusie} fit, each CS element instead combines
-#'     native CS summaries (\code{mvsusie_cs_summary},
-#'     \code{mvsusie_config_summary},
-#'     \code{mvsusie_cs_variant_summary}) with SuSiEx interpretation tables
-#'     (\code{susiex_config_probability},
-#'     \code{susiex_activation_summary}).}
+#'     with a \code{config_prob} column) and \code{config_summary}
+#'     (CS-level post-hoc activation summary, with one row per trait). For one
+#'     multi-output \code{mvsusie} or \code{mfsusie} fit, the return also has
+#'     \code{$mvsusie}, a native summary list with \code{cs_summary},
+#'     \code{config_summary}, and \code{cs_variant_summary}.}
 #'   \item{\code{$coloc_pairwise}}{(when \code{method = "coloc_pairwise"})
 #'     A data.frame with one row per (trait1, trait2, l1, l2)
 #'     combination, columns \code{trait1, trait2, l1, l2, hit1, hit2,
@@ -201,14 +198,16 @@ susie_post_outcome_configuration <- function(input,
   if (identical(method, "susiex") &&
       is_single_multi_output_fit_input(input) &&
       (by_missing || identical(by, "outcome"))) {
-    out$susiex <- multi_output_susiex_summary(
+    multi_output <- multi_output_susiex_summary(
       input,
       outcome_names = outcome_names,
       single_effect_lfsr_cutoff = single_effect_lfsr_cutoff,
       prob_thresh = prob_thresh,
       cs_only = cs_only
     )
-    if (is.null(out$susiex)) return(NULL)
+    if (is.null(multi_output)) return(NULL)
+    out$mvsusie <- multi_output$mvsusie
+    out$susiex <- multi_output$susiex
   } else {
     views <- normalise_to_views(input, by = by)
     if (!is.null(outcome_names)) {
@@ -561,25 +560,25 @@ susiex_configurations <- function(views, by, prob_thresh,
       config_probability
     } else NULL
 
-    activation_summary <- if (!is.null(trait_names) &&
-                              length(trait_names) > 0L) {
+    config_summary <- if (!is.null(trait_names) &&
+                          length(trait_names) > 0L) {
       cs_display <- if (!is.null(tup$cs_labels)) {
         tup$cs_labels[trait_names]
       } else {
         paste0("L", tup$cs_indices[trait_names])
       }
-      vals <- rbind(
+      data.frame(
         cs_indices    = as.character(cs_display),
-        logBF_trait   = as.character(tup$logBF_trait[trait_names]),
-        posthoc_prob  = as.character(tup$marginal_prob[trait_names]),
-        active        = as.character(tup$active[trait_names])
+        logBF_trait   = as.numeric(tup$logBF_trait[trait_names]),
+        posthoc_prob  = as.numeric(tup$marginal_prob[trait_names]),
+        active        = as.logical(tup$active[trait_names]),
+        row.names     = trait_names,
+        check.names   = FALSE
       )
-      colnames(vals) <- trait_names
-      as.data.frame(vals, check.names = FALSE, stringsAsFactors = FALSE)
     } else NULL
 
     out <- list(config_probability = config_probability,
-                activation_summary = activation_summary)
+                config_summary = config_summary)
     attr(out, "raw") <- tup
     out
   })
@@ -748,16 +747,31 @@ multi_output_susiex_summary <- function(input, outcome_names = NULL,
     if (is.list(raw) && !is.null(raw$cs_labels)) raw$cs_labels[[1L]]
     else NA_character_
   }, character(1))
+  names(sx) <- sx_names
 
-  for (nm in names(native)) {
-    pos <- match(nm, sx_names)
-    if (!is.na(pos)) {
-      native[[nm]]$susiex_config_probability <- sx[[pos]]$config_probability
-      native[[nm]]$susiex_activation_summary <- sx[[pos]]$activation_summary
-      attr(native[[nm]], "raw") <- attr(sx[[pos]], "raw", exact = TRUE)
-    }
+  list(mvsusie = flatten_mvsusie_summary(native),
+       susiex = sx[!is.na(names(sx))])
+}
+
+flatten_mvsusie_summary <- function(native) {
+  add_cs <- function(df, cs) {
+    data.frame(cs = rep(cs, nrow(df)), df,
+               check.names = FALSE, row.names = NULL)
   }
-  native
+  cs <- do.call(rbind, lapply(native, `[[`, "mvsusie_cs_summary"))
+  config <- do.call(rbind, Map(function(x, nm) {
+    add_cs(x$mvsusie_config_summary, nm)
+  }, native, names(native)))
+  variants <- do.call(rbind, Map(function(x, nm) {
+    add_cs(x$mvsusie_cs_variant_summary, nm)
+  }, native, names(native)))
+  rownames(cs) <- rownames(config) <- rownames(variants) <- NULL
+
+  list(
+    cs_summary = cs,
+    config_summary = config,
+    cs_variant_summary = variants
+  )
 }
 
 mvsusie_cs_summary <- function(input, outcome_names = NULL,

--- a/R/susie_post_outcome_configuration.R
+++ b/R/susie_post_outcome_configuration.R
@@ -575,7 +575,7 @@ susiex_configurations <- function(views, by, prob_thresh,
       }
       data.frame(
         cs_indices    = as.character(cs_display),
-        logBF_trait   = as.numeric(tup$logBF_trait[trait_names]),
+        logBF_outcome = as.numeric(tup$logBF_trait[trait_names]),
         posthoc_prob  = as.numeric(tup$marginal_prob[trait_names]),
         active        = as.logical(tup$active[trait_names]),
         row.names     = trait_names,
@@ -838,7 +838,7 @@ mvsusie_cs_summary <- function(input, outcome_names = NULL,
         ncol(sentinel_lfsr_mat) == R) {
       sentinel_lfsr <- as.numeric(sentinel_lfsr_mat[hit$hit_idx, ])
     }
-    sentinel_lfsr_pass <- sentinel_lfsr < single_effect_lfsr_cutoff
+    sentinel_lfsr_significant <- sentinel_lfsr < single_effect_lfsr_cutoff
 
     cs_summary <- data.frame(
       cs            = cs$labels[i],
@@ -847,7 +847,7 @@ mvsusie_cs_summary <- function(input, outcome_names = NULL,
       hit           = hit$hit,
       maxPIP        = hit$maxPIP,
       lbf           = effect_lbf[l],
-      n_lfsr_outcome = sum(sentinel_lfsr_pass, na.rm = TRUE),
+      n_lfsr_outcome = sum(sentinel_lfsr_significant, na.rm = TRUE),
       stringsAsFactors = FALSE,
       check.names = FALSE
     )
@@ -878,7 +878,7 @@ mvsusie_cs_summary <- function(input, outcome_names = NULL,
       lbf_outcome = as.numeric(logBF_mat[l, ]),
       sentinel_variant = rep(hit$hit, R),
       sentinel_lfsr = sentinel_lfsr,
-      lfsr_pass = sentinel_lfsr_pass,
+      lfsr_significant = sentinel_lfsr_significant,
       lfsr_cutoff = rep(single_effect_lfsr_cutoff, R),
       stringsAsFactors = FALSE,
       check.names = FALSE

--- a/R/susie_post_outcome_configuration.R
+++ b/R/susie_post_outcome_configuration.R
@@ -63,7 +63,8 @@
 #'     every trait pair and CS pair. It asks whether same-SNP evidence is
 #'     stronger than distinct-causal evidence, represented by terms such as
 #'     \eqn{\sum_{j \ne k}\exp(\ell_{1j}+\ell_{2k})}; this separates H3,
-#'     two distinct causal variants, from H4, one shared causal variant.}
+#'     two distinct causal variants, from H4, one shared causal variant.
+#'     Per-SNP log Bayes factors are aligned by variant name when available.}
 #' }
 #'
 #' \subsection{Two-trait example}{
@@ -339,7 +340,7 @@ enumerate_cs_tuples <- function(views, by, cs_only) {
   if (!is.null(alpha_names) && !is.null(lbf_names) &&
       !identical(alpha_names, lbf_names)) {
     stop("Trait '", view$name, "': column names of `alpha` and `lbf` ",
-         "must match for SuSiEx variant-level configuration scoring.")
+         "must match for variant-level post-hoc scoring.")
   }
   keys <- if (!is.null(lbf_names)) lbf_names else alpha_names
   if (is.null(keys)) keys <- paste0(".variant_", seq_len(ncol(view$lbf)))
@@ -476,6 +477,10 @@ coloc_pairwise_abf <- function(views, p1, p2, p12) {
   if (N < 2L) return(empty)
 
   trait_names <- vapply(views, function(v) v$name, character(1))
+  variant_keys <- lapply(views, .view_variant_keys)
+  variant_named <- vapply(views, function(v) {
+    !is.null(colnames(v$alpha)) || !is.null(colnames(v$lbf))
+  }, logical(1))
   rows <- list()
 
   for (a in seq_len(N - 1L)) {
@@ -484,28 +489,38 @@ coloc_pairwise_abf <- function(views, p1, p2, p12) {
       L2 <- view_cs_indices(views[[b]], cs_only = TRUE)
       if (length(L1) == 0L || length(L2) == 0L) next
 
-      var_names_a <- colnames(views[[a]]$lbf)
-      var_names_b <- colnames(views[[b]]$lbf)
+      keys_a <- variant_keys[[a]]
+      keys_b <- variant_keys[[b]]
+      if ((!variant_named[a] || !variant_named[b]) &&
+          length(keys_a) != length(keys_b)) {
+        stop("coloc_pairwise: cannot align unnamed variant sets with ",
+             "different lengths for traits '", trait_names[a], "' and '",
+             trait_names[b], "'.")
+      }
+      common <- intersect(keys_a, keys_b)
+      if (length(common) == 0L) {
+        stop("coloc_pairwise: no overlapping variants between traits '",
+             trait_names[a], "' and '", trait_names[b], "'.")
+      }
+      idx_a <- match(common, keys_a)
+      idx_b <- match(common, keys_b)
+      hit_names <- if (variant_named[a] || variant_named[b]) {
+        common
+      } else {
+        paste0("snp_", idx_a)
+      }
 
       for (i in L1) {
         if (all(views[[a]]$alpha[i, ] == 0)) next
-        l1_row <- views[[a]]$lbf[i, ]
+        l1_row <- views[[a]]$lbf[i, idx_a]
         for (j in L2) {
           if (all(views[[b]]$alpha[j, ] == 0)) next
-          l2_row <- views[[b]]$lbf[j, ]
+          l2_row <- views[[b]]$lbf[j, idx_b]
 
           pp <- combine_abf_pair(l1_row, l2_row, p1 = p1, p2 = p2, p12 = p12)
 
-          hit1 <- if (!is.null(var_names_a)) {
-                    var_names_a[which.max(l1_row)]
-                  } else {
-                    paste0("snp_", which.max(l1_row))
-                  }
-          hit2 <- if (!is.null(var_names_b)) {
-                    var_names_b[which.max(l2_row)]
-                  } else {
-                    paste0("snp_", which.max(l2_row))
-                  }
+          hit1 <- hit_names[which.max(l1_row)]
+          hit2 <- hit_names[which.max(l2_row)]
 
           rows[[length(rows) + 1L]] <- data.frame(
             trait1 = trait_names[a], trait2 = trait_names[b],

--- a/R/susie_post_outcome_configuration.R
+++ b/R/susie_post_outcome_configuration.R
@@ -83,8 +83,6 @@
 #' colocalisation model over H0-H4 for each CS pair. Both are summaries of
 #' already fitted SuSiE-class models; neither refits the single-trait effects.
 #'
-#' To get both methods, call the function twice and combine the outputs.
-#'
 #' @param input A single fit of class \code{susie}, \code{mvsusie}, or
 #'   \code{mfsusie}, OR a list of such fits.
 #' @param by Either \code{"fit"} (one trait per input fit; default) or

--- a/R/susie_post_outcome_configuration.R
+++ b/R/susie_post_outcome_configuration.R
@@ -14,6 +14,9 @@
 #     verbatim port of `coloc:::combine.abf` so susieR has no soft
 #     dependency on coloc.
 #
+#   * mvSuSiE CS-level summary: for one multi-output mvsusie/mfsusie fit,
+#     organize native mvSuSiE CS/effect evidence into readable tables.
+#
 # The public function normalises any supported input shape (single fit, list
 # of fits, or a single multi-output fit treated outcome-wise) to a flat list
 # of "trait views", then runs the requested algorithms against that list.
@@ -24,23 +27,25 @@
 
 #' Post-hoc causal-configuration probabilities for one or more SuSiE-class fits
 #'
-#' Runs one of two complementary post-hoc analyses, selected by
+#' Runs one of three complementary post-hoc analyses, selected by
 #' \code{method}: \code{"susiex"} (default) for the SuSiEx \eqn{2^N}
 #' combinatorial enumeration, reporting posterior probabilities over
-#' binary causality patterns across the \eqn{N} input traits; or
+#' binary causality patterns across the \eqn{N} input traits;
 #' \code{"coloc_pairwise"} for the coloc pairwise ABF, reporting the
 #' five colocalisation hypothesis posteriors (H0/H1/H2/H3/H4) for every
-#' pair of traits. To get both, call the function twice and combine.
+#' pair of traits; or \code{"mvsusie"} for CS-level summaries
+#' from one multi-output mvSuSiE fit. To get multiple views, call the
+#' function more than once and combine.
 #'
-#' Two grouping modes are supported through the \code{by} argument:
+#' Three input organizations are supported:
 #' \describe{
-#'   \item{\code{"fit"}}{Each input fit contributes a single trait view.
+#'   \item{\code{by = "fit"}}{Each input fit contributes a single trait view.
 #'     Multi-output fits (\code{mvsusie}, \code{mfsusie}) are kept whole: the
 #'     trait's per-(CS, SNP) log Bayes factors are the joint composite
 #'     stored on the fit as \code{lbf_variable}. Configuration enumeration
 #'     loops over the cross-product \eqn{L_1 \times \dots \times L_N} of CS
 #'     indices.}
-#'   \item{\code{"outcome"}}{Multi-output fits fan out into per-outcome views,
+#'   \item{\code{by = "outcome"}}{Multi-output fits fan out into per-outcome views,
 #'     each with its own per-(CS, SNP) log Bayes factors read from
 #'     \code{fit$lbf_variable_outcome} (an \eqn{L \times J \times R} or
 #'     \eqn{L \times J \times M} array). All per-outcome views share the
@@ -48,6 +53,8 @@
 #'     reduces to a single index \eqn{l \in 1..L}. Single-output \code{susie}
 #'     fits pass through unchanged. Requires \code{$lbf_variable_outcome} on the
 #'     fit (set \code{attach_lbf_variable_outcome = TRUE} when fitting).}
+#'   \item{\code{method = "mvsusie"}}{One multi-output mvSuSiE fit is used
+#'     directly, and results are summarized at the CS/effect level.}
 #' }
 #'
 #' After SuSiE has been fit, the post-hoc step can answer two related
@@ -108,9 +115,9 @@
 #'   \code{NULL}, names are taken from the input list when available, otherwise
 #'   \code{trait_1}, \code{trait_2}, ... are used. If provided, its length must
 #'   match the number of trait views after applying \code{by}.
-#' @param method Character scalar; one of \code{"susiex"} (default) or
-#'   \code{"coloc_pairwise"}. Pick the analysis to run; for both, call
-#'   the function twice.
+#' @param method Character scalar; one of \code{"susiex"} (default),
+#'   \code{"coloc_pairwise"}, or \code{"mvsusie"}. Pick the analysis to run;
+#'   for multiple analyses, call the function more than once.
 #' @param prob_thresh Per-trait marginal threshold for the convenience
 #'   \code{$active} flags in the SuSiEx output. Default \code{0.8}.
 #' @param cs_only Logical. If \code{TRUE} (default) only enumerate over CSs
@@ -140,6 +147,11 @@
 #'     A data.frame with one row per (trait1, trait2, l1, l2)
 #'     combination, columns \code{trait1, trait2, l1, l2, hit1, hit2,
 #'     PP.H0, PP.H1, PP.H2, PP.H3, PP.H4}.}
+#'   \item{\code{$mvsusie}}{(when \code{method = "mvsusie"}) A CS-level
+#'     data.frame for one multi-output \code{mvsusie} or \code{mfsusie}
+#'     fit. The table organizes mvSuSiE-native quantities: CS label,
+#'     single-effect index, sentinel hit, max PIP, overall log BF,
+#'     per-outcome log BF, and \code{single_effect_lfsr}.}
 #' }
 #' Pretty-print with \code{summary(out)}.
 #'
@@ -154,7 +166,8 @@ susie_post_outcome_configuration <- function(input,
                                              by          = c("fit", "outcome"),
                                              outcome_names = NULL,
                                              method      = c("susiex",
-                                                             "coloc_pairwise"),
+                                                             "coloc_pairwise",
+                                                             "mvsusie"),
                                              prob_thresh = 0.8,
                                              cs_only     = TRUE,
                                              p1          = 1e-4,
@@ -179,32 +192,39 @@ susie_post_outcome_configuration <- function(input,
     }
   }
 
-  views <- normalise_to_views(input, by = by)
-  if (!is.null(outcome_names)) {
-    if (!is.character(outcome_names) ||
-        length(outcome_names) != length(views) ||
-        anyNA(outcome_names) || any(!nzchar(outcome_names))) {
-      stop("`outcome_names` must be a non-empty character vector with ",
-           "length equal to the number of trait views.")
-    }
-    for (k in seq_along(views)) {
-      views[[k]]$name <- outcome_names[k]
-    }
-  }
-  views <- filter_views_for_posthoc(views, cs_only = cs_only)
-  if (is.null(views)) return(NULL)
-
   out <- list()
-  if (identical(method, "susiex")) {
-    out$susiex <- susiex_configurations(views,
-                                        by          = by,
-                                        prob_thresh = prob_thresh)
+  if (identical(method, "mvsusie")) {
+    out$mvsusie <- mvsusie_cs_summary(input,
+                                      outcome_names = outcome_names,
+                                      cs_only       = cs_only)
+    if (is.null(out$mvsusie)) return(NULL)
   } else {
-    # method == "coloc_pairwise"
-    out$coloc_pairwise <- coloc_pairwise_abf(views,
-                                             p1  = p1,
-                                             p2  = p2,
-                                             p12 = p12)
+    views <- normalise_to_views(input, by = by)
+    if (!is.null(outcome_names)) {
+      if (!is.character(outcome_names) ||
+          length(outcome_names) != length(views) ||
+          anyNA(outcome_names) || any(!nzchar(outcome_names))) {
+        stop("`outcome_names` must be a non-empty character vector with ",
+             "length equal to the number of trait views.")
+      }
+      for (k in seq_along(views)) {
+        views[[k]]$name <- outcome_names[k]
+      }
+    }
+    views <- filter_views_for_posthoc(views, cs_only = cs_only)
+    if (is.null(views)) return(NULL)
+
+    if (identical(method, "susiex")) {
+      out$susiex <- susiex_configurations(views,
+                                          by          = by,
+                                          prob_thresh = prob_thresh)
+    } else {
+      # method == "coloc_pairwise"
+      out$coloc_pairwise <- coloc_pairwise_abf(views,
+                                               p1  = p1,
+                                               p2  = p2,
+                                               p12 = p12)
+    }
   }
   attr(out, "prob_thresh") <- prob_thresh
   attr(out, "method")      <- method
@@ -535,6 +555,181 @@ susiex_configurations <- function(views, by, prob_thresh,
     attr(out, "raw") <- tup
     out
   })
+}
+
+
+# -----------------------------------------------------------------------------
+# mvSuSiE CS-level summary helpers.
+# -----------------------------------------------------------------------------
+
+as_single_mvsusie_fit <- function(input) {
+  is_mv <- function(x) inherits(x, "mvsusie") || inherits(x, "mfsusie")
+  if (is_mv(input)) return(input)
+  if (is.list(input) && length(input) == 1L && is_mv(input[[1L]])) {
+    return(input[[1L]])
+  }
+  stop("method = \"mvsusie\" requires one multi-output fit of class ",
+       "`mvsusie` or `mfsusie`.")
+}
+
+mvsusie_names <- function(candidates, n, prefix, provided = NULL,
+                          what = "names") {
+  if (!is.null(provided)) {
+    if (!is.character(provided) || length(provided) != n ||
+        anyNA(provided) || any(!nzchar(provided))) {
+      stop("`", what, "` must be a non-empty character vector of length ", n, ".")
+    }
+    return(provided)
+  }
+  for (x in candidates) {
+    if (!is.null(x) && length(x) == n && all(!is.na(x)) && all(nzchar(x))) {
+      return(as.character(x))
+    }
+  }
+  paste0(prefix, seq_len(n))
+}
+
+mvsusie_lbf_outcome <- function(fit) {
+  if (!is.null(fit$lbf_outcome)) {
+    x <- fit$lbf_outcome
+    if (!is.matrix(x)) x <- as.matrix(x)
+    return(x)
+  }
+
+  if (is.null(fit$alpha) || is.null(fit$lbf_variable_outcome)) {
+    stop("method = \"mvsusie\" requires `$lbf_outcome`, or both `$alpha` ",
+         "and `$lbf_variable_outcome` to compute CS-level log Bayes factors.")
+  }
+  alpha <- fit$alpha
+  arr <- fit$lbf_variable_outcome
+  if (!is.matrix(alpha) || length(dim(arr)) != 3L ||
+      nrow(alpha) != dim(arr)[1L] || ncol(alpha) != dim(arr)[2L]) {
+    stop("For method = \"mvsusie\", `$alpha` must be L x J and ",
+         "`$lbf_variable_outcome` must be L x J x R with matching L and J.")
+  }
+
+  out <- matrix(0, nrow = dim(arr)[1L], ncol = dim(arr)[3L])
+  for (l in seq_len(nrow(out))) {
+    out[l, ] <- as.vector(crossprod(alpha[l, ], arr[l, , ]))
+  }
+  colnames(out) <- dimnames(arr)[[3L]]
+  out
+}
+
+mvsusie_cs_indices <- function(fit, cs_only) {
+  view <- list(alpha = fit$alpha, sets_cs = fit$sets$cs)
+  idx <- view_cs_indices(view, cs_only = cs_only)
+  list(idx = idx,
+       labels = vapply(idx, function(l) view_cs_label(view, l), character(1)))
+}
+
+mvsusie_cs_hit <- function(fit, label, idx, variable_names) {
+  cs <- fit$sets$cs
+  empty <- list(n_cs = 0L, hit = NA_character_, maxPIP = NA_real_)
+  if (is.null(cs) || length(cs) == 0L) return(empty)
+
+  pos <- if (!is.null(names(cs))) match(label, names(cs)) else NA_integer_
+  if (is.na(pos)) {
+    cs_idx <- attr(cs, "cs_idx")
+    if (!is.null(cs_idx)) pos <- match(idx, cs_idx)
+  }
+  if (is.na(pos) || pos < 1L || pos > length(cs)) return(empty)
+
+  members <- cs[[pos]]
+  if (length(members) == 0L || is.null(fit$pip)) {
+    empty$n_cs <- length(members)
+    return(empty)
+  }
+  if (is.character(members)) {
+    idx <- match(members, variable_names)
+  } else {
+    idx <- as.integer(members)
+  }
+  idx <- idx[!is.na(idx) & idx >= 1L & idx <= length(fit$pip)]
+  if (length(idx) == 0L) {
+    empty$n_cs <- length(members)
+    return(empty)
+  }
+
+  pip <- fit$pip[idx]
+  best <- idx[which.max(pip)]
+  list(n_cs = length(members), hit = variable_names[best],
+       maxPIP = unname(fit$pip[best]))
+}
+
+mvsusie_cs_summary <- function(input, outcome_names = NULL, cs_only) {
+  fit <- as_single_mvsusie_fit(input)
+  logBF_mat <- mvsusie_lbf_outcome(fit)
+  if (nrow(logBF_mat) != nrow(fit$alpha)) {
+    stop("For method = \"mvsusie\", `$lbf_outcome` must have one row per ",
+         "single effect in `$alpha`.")
+  }
+
+  R <- ncol(logBF_mat)
+  if (R < 2L) {
+    message("Fewer than two outcomes in mvSuSiE fit; returning NULL.")
+    return(NULL)
+  }
+  trait_names <- mvsusie_names(
+    list(colnames(fit$lbf_outcome), colnames(fit$single_effect_lfsr),
+         fit$outcome_names,
+         if (!is.null(fit$lbf_variable_outcome)) {
+           dimnames(fit$lbf_variable_outcome)[[3L]]
+         } else NULL),
+    n = R, prefix = "outcome_", provided = outcome_names,
+    what = "outcome_names"
+  )
+
+  cs <- mvsusie_cs_indices(fit, cs_only = cs_only)
+  if (length(cs$idx) == 0L) {
+    message("No credible sets available for mvSuSiE CS summary; ",
+            "returning NULL.")
+    return(NULL)
+  }
+
+  lfsr_mat <- fit$single_effect_lfsr
+  if (!is.null(lfsr_mat) && !is.matrix(lfsr_mat)) lfsr_mat <- as.matrix(lfsr_mat)
+  effect_lbf <- rep(NA_real_, nrow(fit$alpha))
+  if (!is.null(fit$lbf)) {
+    lbf <- as.numeric(unlist(fit$lbf, use.names = FALSE))
+    effect_lbf[seq_len(min(length(lbf), length(effect_lbf)))] <- lbf
+  }
+  variable_names <- mvsusie_names(
+    list(fit$variable_names, names(fit$pip), colnames(fit$alpha),
+         colnames(fit$lbf_variable)),
+    n = ncol(fit$alpha), prefix = "", what = "variable names"
+  )
+
+  out <- vector("list", length(cs$idx))
+  for (i in seq_along(cs$idx)) {
+    l <- cs$idx[i]
+    if (all(fit$alpha[l, ] == 0)) next
+
+    single_effect_lfsr <- rep(NA_real_, R)
+    if (!is.null(lfsr_mat) && nrow(lfsr_mat) >= l && ncol(lfsr_mat) == R) {
+      single_effect_lfsr <- as.numeric(lfsr_mat[l, ])
+    }
+
+    hit <- mvsusie_cs_hit(fit, label = cs$labels[i], idx = l,
+                          variable_names = variable_names)
+    row <- data.frame(
+      cs            = cs$labels[i],
+      single_effect = l,
+      n_cs          = hit$n_cs,
+      hit           = hit$hit,
+      maxPIP        = hit$maxPIP,
+      lbf           = effect_lbf[l],
+      stringsAsFactors = FALSE,
+      check.names = FALSE
+    )
+    row[paste0("lbf_outcome.", trait_names)] <- as.list(as.numeric(logBF_mat[l, ]))
+    row[paste0("single_effect_lfsr.", trait_names)] <- as.list(single_effect_lfsr)
+    out[[i]] <- row
+  }
+
+  out <- out[!vapply(out, is.null, logical(1))]
+  if (length(out) == 0L) return(data.frame())
+  do.call(rbind, out)
 }
 
 # -----------------------------------------------------------------------------

--- a/man/susie_post_outcome_configuration.Rd
+++ b/man/susie_post_outcome_configuration.Rd
@@ -64,13 +64,15 @@ post-hoc analysis; otherwise a list of class
 components, depending on \code{method}:
 \describe{
   \item{\code{$susiex}}{(when \code{method = "susiex"}) A list of length
-    equal to the number of CS tuples considered. Each element has
+    equal to the number of CS tuples considered, named \code{config_1},
+    \code{config_2}, etc. Each element has
     components \code{config_probability} (binary trait-activation table
     with a \code{config_prob} column) and \code{config_summary}
     (CS-level post-hoc activation summary, with one row per trait). For one
-    multi-output \code{mvsusie} or \code{mfsusie} fit, the return also has
-    \code{$mvsusie}, a native summary list with \code{cs_summary},
-    \code{config_summary}, and \code{cs_variant_summary}.}
+    multi-output \code{mvsusie} or \code{mfsusie} fit, both \code{$susiex}
+    and \code{$mvsusie} are named by CS label, e.g. \code{L1}; each
+    \code{$mvsusie} element has \code{cs_summary}, \code{config_summary},
+    and \code{cs_variant_summary}.}
   \item{\code{$coloc_pairwise}}{(when \code{method = "coloc_pairwise"})
     A data.frame with one row per (trait1, trait2, l1, l2)
     combination, columns \code{trait1, trait2, l1, l2, hit1, hit2,

--- a/man/susie_post_outcome_configuration.Rd
+++ b/man/susie_post_outcome_configuration.Rd
@@ -7,6 +7,7 @@
 susie_post_outcome_configuration(
   input,
   by = c("fit", "outcome"),
+  outcome_names = NULL,
   method = c("susiex", "coloc_pairwise"),
   prob_thresh = 0.8,
   cs_only = TRUE,
@@ -22,6 +23,11 @@ susie_post_outcome_configuration(
 
 \item{by}{Either \code{"fit"} (one trait per input fit; default) or
 \code{"outcome"} (multi-output fits expand into per-outcome traits).}
+
+\item{outcome_names}{Optional character vector of trait-view names. If
+\code{NULL}, names are taken from the input list when available, otherwise
+\code{trait_1}, \code{trait_2}, ... are used. If provided, its length must
+match the number of trait views after applying \code{by}.}
 
 \item{method}{Character scalar; one of \code{"susiex"} (default) or
 \code{"coloc_pairwise"}. Pick the analysis to run; for both, call

--- a/man/susie_post_outcome_configuration.Rd
+++ b/man/susie_post_outcome_configuration.Rd
@@ -118,16 +118,32 @@ Coloc has five hypotheses: H0, no causal variant; H1, trait 1 only; H2,
 trait 2 only; H3, two distinct causal variants; and H4, one shared causal
 variant. Thus coloc splits the active two-trait case into H3 and H4,
 whereas SuSiEx represents it as the single activation state \eqn{(1,1)}.
-}
 
-The \code{"susiex"} output is an \eqn{N}-trait post-hoc activation model
+The \code{"susiex"} output is an \eqn{2}-trait post-hoc activation model
 over CS tuples. The \code{"coloc_pairwise"} output is a pairwise
 colocalisation model over H0-H4 for each CS pair. Both are summaries of
 already fitted SuSiE-class models; neither refits the single-trait effects.
+}
 
-To get both methods, call the function twice and combine the outputs.
+More generally, in \eqn{N}-trait analysis, the difference between
+SuSiEx-style activation and colocalization is a difference in hypothesis
+space:
+\describe{
+  \item{SuSiEx activation space}{\code{"susiex"} is an \eqn{N}-trait
+    post-hoc activation, or meta-analysis-style, model over CS tuples. It
+    enumerates the \eqn{2^N} binary activity patterns and asks which traits
+    participate in a proposed shared event.}
+  \item{Colocalization partition space}{A theoretical generalization to
+    \eqn{N}-trait colocalization has a larger hypothesis space: inactive
+    traits plus all ways of grouping active traits by shared causal
+    variant, of size Bell(\eqn{N+1}) (see HyPrColoc, Figure 1). This space
+    asks not only which traits are active, but which active traits share
+    the same causal variant versus distinct causal variants.}
+}
 }
 \references{
 SuSiEx, Nature Genetics 2024 (combinatorial \eqn{2^N} enumeration).
 Wallace, PLoS Genetics 2020 (coloc pairwise H0/H1/H2/H3/H4 ABF).
+Foley et al., Nature Communications 2021 (HyPrColoc; multi-trait
+colocalisation hypothesis space in Figure 1).
 }

--- a/man/susie_post_outcome_configuration.Rd
+++ b/man/susie_post_outcome_configuration.Rd
@@ -67,8 +67,8 @@ Pretty-print with \code{summary(out)}.
 \description{
 Runs one of two complementary post-hoc analyses, selected by
 \code{method}: \code{"susiex"} (default) for the SuSiEx \eqn{2^N}
-combinatorial enumeration, reporting the posterior probability of
-every binary causality pattern across the \eqn{N} input traits; or
+combinatorial enumeration, reporting posterior probabilities over
+binary causality patterns across the \eqn{N} input traits; or
 \code{"coloc_pairwise"} for the coloc pairwise ABF, reporting the
 five colocalisation hypothesis posteriors (H0/H1/H2/H3/H4) for every
 pair of traits. To get both, call the function twice and combine.
@@ -92,75 +92,40 @@ Two grouping modes are supported through the \code{by} argument:
     fit (set \code{attach_lbf_variable_outcome = TRUE} when fitting).}
 }
 
-\subsection{SuSiEx algorithm}{
-For each credible-set tuple \eqn{(l_1, \dots, l_N)}, the \code{"susiex"}
-method computes post hoc probabilities of causal configurations following
-the SuSiEx activation-configuration framework.
-
-\enumerate{
-  \item Enumerate the \eqn{2^N} activation configurations
-    \eqn{c \in \{0,1\}^N}. Here \eqn{c_n = 1} indicates that, under this
-    configuration, the signal in the tuple is causal in trait / population
-    \eqn{n}.
-  \item For \eqn{c \ne 0}, score the configuration on aligned variants
-    \eqn{\mathcal V_c = \cap_{n:c_n=1}\mathcal V_n}:
-    \deqn{\log W(c) =
-      \log\sum_{j \in \mathcal V_c} \pi_j
-      \exp\{\sum_{n:c_n=1}\log\mathrm{BF}_{n,l_n,j}\},}
-    with \eqn{\pi_j} uniform over aligned variants and \eqn{\log W(0)=0}.
-  \item Normalise under a uniform prior over the \eqn{2^N} activation
-    configurations.
-  \item Per-trait marginal: \eqn{P(\mathrm{trait}\,n\,\mathrm{causal}) =
-    \sum_{c: c_n = 1} P(c \mid \mathrm{tuple})}.
+After SuSiE has been fit, the post-hoc step can answer two related
+questions:
+\describe{
+  \item{\code{"susiex"}}{SuSiEx \eqn{2^N} activation probabilities for
+    each credible-set tuple. It asks which traits have evidence for a
+    proposed shared CS-level event. In two traits, the both-active state
+    uses same-SNP evidence such as
+    \eqn{\sum_j \exp(\ell_{1j}+\ell_{2j})}, where \eqn{\ell_{tj}} is the
+    SNP-level log Bayes factor for trait \eqn{t}.}
+  \item{\code{"coloc_pairwise"}}{Pairwise coloc H0-H4 posteriors for
+    every trait pair and CS pair. It asks whether same-SNP evidence is
+    stronger than distinct-causal evidence, represented by terms such as
+    \eqn{\sum_{j \ne k}\exp(\ell_{1j}+\ell_{2k})}; this separates H3,
+    two distinct causal variants, from H4, one shared causal variant.}
 }
 
-The \eqn{2^N} activation space is a coherent post hoc model for a candidate
-credible-set event. It is especially useful in cross-population fine-mapping,
-where a proposed shared causal event may be causal or detectable in only a
-subset of populations because of differences in LD, allele frequency, sample
-size, or effect size.
+\subsection{Two-trait example}{
+For two traits and one CS pair, SuSiEx has four activation states:
+\eqn{(0,0)}, \eqn{(1,0)}, \eqn{(0,1)}, and \eqn{(1,1)}. The state
+\eqn{(1,1)} means both traits are active for the candidate shared event;
+it does not introduce a separate distinct-causal state.
 
-This activation space should be distinguished from the complete coloc-style
-sharing space. A complete colocalisation model also allows active traits to
-split into distinct causal groups. With inactive traits allowed, this is a
-partial-partition space of size Bell(\eqn{N+1}). In other words,
-SuSiEx-style activation asks which traits participate in one candidate
-event, whereas a complete coloc-style model asks how active traits are
-partitioned into one or more causal events.
-
-For two traits, the SuSiEx-style activation space contains
-\eqn{H(0,0)}, \eqn{H(1,0)}, \eqn{H(0,1)}, and \eqn{H(1,1)}. Coloc further
-separates the active state \eqn{H(1,1)} into two competing explanations:
-H3, where both traits are active but have distinct causal variants, and H4,
-where both traits share one causal variant.
-
+Coloc has five hypotheses: H0, no causal variant; H1, trait 1 only; H2,
+trait 2 only; H3, two distinct causal variants; and H4, one shared causal
+variant. Thus coloc splits the active two-trait case into H3 and H4,
+whereas SuSiEx represents it as the single activation state \eqn{(1,1)}.
 }
 
-\subsection{Coloc pairwise algorithm}{
-For each unordered trait pair \eqn{(n, n')} and each CS pair
-\eqn{(l_n, l_{n'})}, with per-SNP log BFs
-\eqn{\ell_1 = \log\mathrm{BF}_{n,l_n,\cdot}} and
-\eqn{\ell_2 = \log\mathrm{BF}_{n',l_{n'},\cdot}} (length \eqn{J}), the
-five hypothesis log-BFs are
-\deqn{\log\mathrm{BF}_{H_0} = 0,\quad
-      \log\mathrm{BF}_{H_1} = \log p_1 + \mathrm{LSE}(\ell_1),\quad
-      \log\mathrm{BF}_{H_2} = \log p_2 + \mathrm{LSE}(\ell_2),}
-\deqn{\log\mathrm{BF}_{H_3} = \log p_1 + \log p_2 +
-      \mathrm{logdiff}(\mathrm{LSE}(\ell_1) + \mathrm{LSE}(\ell_2),\;
-                       \mathrm{LSE}(\ell_1 + \ell_2)),}
-\deqn{\log\mathrm{BF}_{H_4} = \log p_{12} + \mathrm{LSE}(\ell_1 + \ell_2),}
-and the corresponding posteriors are
-\eqn{\mathrm{PP.H}_h = \exp(\log\mathrm{BF}_{H_h} -
-      \mathrm{LSE}(\log\mathrm{BF}_{H_0:H_4}))}, where
-\eqn{\mathrm{LSE}} is the log-sum-exp.
-\itemize{
-  \item H0: no causal variant in either CS.
-  \item H1: causal in trait \eqn{n} only.
-  \item H2: causal in trait \eqn{n'} only.
-  \item H3: distinct causals in the two traits.
-  \item H4: a single shared causal variant.
-}
-}
+The \code{"susiex"} output is an \eqn{N}-trait post-hoc activation model
+over CS tuples. The \code{"coloc_pairwise"} output is a pairwise
+colocalisation model over H0-H4 for each CS pair. Both are summaries of
+already fitted SuSiE-class models; neither refits the single-trait effects.
+
+To get both methods, call the function twice and combine the outputs.
 }
 \references{
 SuSiEx, Nature Genetics 2024 (combinatorial \eqn{2^N} enumeration).

--- a/man/susie_post_outcome_configuration.Rd
+++ b/man/susie_post_outcome_configuration.Rd
@@ -66,13 +66,11 @@ components, depending on \code{method}:
   \item{\code{$susiex}}{(when \code{method = "susiex"}) A list of length
     equal to the number of CS tuples considered. Each element has
     components \code{config_probability} (binary trait-activation table
-    with a \code{config_prob} column) and \code{activation_summary}
-    (CS-level post-hoc activation summary by trait). For one multi-output
-    \code{mvsusie} or \code{mfsusie} fit, each CS element instead combines
-    native CS summaries (\code{mvsusie_cs_summary}, \code{mvsusie_config_summary},
-    \code{mvsusie_cs_variant_summary}) with SuSiEx interpretation tables
-    (\code{susiex_config_probability},
-    \code{susiex_activation_summary}).}
+    with a \code{config_prob} column) and \code{config_summary}
+    (CS-level post-hoc activation summary, with one row per trait). For one
+    multi-output \code{mvsusie} or \code{mfsusie} fit, the return also has
+    \code{$mvsusie}, a native summary list with \code{cs_summary},
+    \code{config_summary}, and \code{cs_variant_summary}.}
   \item{\code{$coloc_pairwise}}{(when \code{method = "coloc_pairwise"})
     A data.frame with one row per (trait1, trait2, l1, l2)
     combination, columns \code{trait1, trait2, l1, l2, hit1, hit2,

--- a/man/susie_post_outcome_configuration.Rd
+++ b/man/susie_post_outcome_configuration.Rd
@@ -57,15 +57,8 @@ exactly one of the following components, depending on \code{method}:
   \item{\code{$susiex}}{(when \code{method = "susiex"}) A list of length
     equal to the number of CS tuples considered. Each element has
     components \code{config_probability} (binary trait-activation table
-    with a \code{config_prob} column), \code{activation_summary}
-    (CS-level post-hoc activation summary by trait), \code{cs_indices}
-    (length-N integer tuple),
-    \code{logBF_trait} (length-N singleton activation log BF),
-    \code{configs} (\eqn{2^N \times N} binary matrix),
-    \code{config_prob} (length \eqn{2^N}),
-    \code{marginal_prob} (length-N per-trait marginal posterior
-    probability of being active across the configuration ensemble),
-    and \code{active} (logical, \code{marginal_prob >= prob_thresh}).}
+    with a \code{config_prob} column) and \code{activation_summary}
+    (CS-level post-hoc activation summary by trait).}
   \item{\code{$coloc_pairwise}}{(when \code{method = "coloc_pairwise"})
     A data.frame with one row per (trait1, trait2, l1, l2)
     combination, columns \code{trait1, trait2, l1, l2, hit1, hit2,

--- a/man/susie_post_outcome_configuration.Rd
+++ b/man/susie_post_outcome_configuration.Rd
@@ -56,10 +56,13 @@ exactly one of the following components, depending on \code{method}:
 \describe{
   \item{\code{$susiex}}{(when \code{method = "susiex"}) A list of length
     equal to the number of CS tuples considered. Each element has
-    components \code{cs_indices} (length-N integer tuple),
+    components \code{config_probability} (binary trait-activation table
+    with a \code{config_prob} column), \code{activation_summary}
+    (CS-level post-hoc activation summary by trait), \code{cs_indices}
+    (length-N integer tuple),
     \code{logBF_trait} (length-N singleton activation log BF),
-    \code{configs} (\eqn{2^N \times N}
-    binary matrix), \code{config_prob} (length \eqn{2^N}),
+    \code{configs} (\eqn{2^N \times N} binary matrix),
+    \code{config_prob} (length \eqn{2^N}),
     \code{marginal_prob} (length-N per-trait marginal posterior
     probability of being active across the configuration ensemble),
     and \code{active} (logical, \code{marginal_prob >= prob_thresh}).}

--- a/man/susie_post_outcome_configuration.Rd
+++ b/man/susie_post_outcome_configuration.Rd
@@ -40,7 +40,7 @@ zero are skipped. When \code{TRUE}, every fit must carry a non-null
 alone, \code{p2} for trait 2 alone, \code{p12} for shared causal.
 Defaults match \code{coloc::coloc.bf_bf}: \code{p1 = p2 = 1e-4},
 \code{p12 = 5e-6}. Only used when \code{"coloc_pairwise"} is in
-\code{methods}.}
+\code{method}.}
 
 \item{...}{Currently ignored.}
 }
@@ -51,7 +51,8 @@ exactly one of the following components, depending on \code{method}:
   \item{\code{$susiex}}{(when \code{method = "susiex"}) A list of length
     equal to the number of CS tuples considered. Each element has
     components \code{cs_indices} (length-N integer tuple),
-    \code{logBF_trait} (length N), \code{configs} (\eqn{2^N \times N}
+    \code{logBF_trait} (length-N singleton activation log BF),
+    \code{configs} (\eqn{2^N \times N}
     binary matrix), \code{config_prob} (length \eqn{2^N}),
     \code{marginal_prob} (length-N per-trait marginal posterior
     probability of being active across the configuration ensemble),
@@ -92,19 +93,47 @@ Two grouping modes are supported through the \code{by} argument:
 }
 
 \subsection{SuSiEx algorithm}{
-For each credible-set tuple \eqn{(l_1, \dots, l_N)}:
+For each credible-set tuple \eqn{(l_1, \dots, l_N)}, the \code{"susiex"}
+method computes post hoc probabilities of causal configurations following
+the SuSiEx activation-configuration framework.
+
 \enumerate{
-  \item Per-trait CS-level log BF (alpha-weighted SNP average):
-    \deqn{\log\mathrm{BF}^{(n)}_{l_n} = \sum_j \alpha_{n,l_n,j}\,
-      \log\mathrm{BF}_{n,l_n,j}.}
-  \item Enumerate the \eqn{2^N} binary configurations
-    \eqn{c \in \{0,1\}^N}.
-  \item Configuration log BF:
-    \deqn{\log\mathrm{BF}^{(c)} = \sum_{n: c_n = 1} \log\mathrm{BF}^{(n)}_{l_n}.}
-  \item Normalise under a uniform prior over the \eqn{2^N} configurations.
+  \item Enumerate the \eqn{2^N} activation configurations
+    \eqn{c \in \{0,1\}^N}. Here \eqn{c_n = 1} indicates that, under this
+    configuration, the signal in the tuple is causal in trait / population
+    \eqn{n}.
+  \item For \eqn{c \ne 0}, score the configuration on aligned variants
+    \eqn{\mathcal V_c = \cap_{n:c_n=1}\mathcal V_n}:
+    \deqn{\log W(c) =
+      \log\sum_{j \in \mathcal V_c} \pi_j
+      \exp\{\sum_{n:c_n=1}\log\mathrm{BF}_{n,l_n,j}\},}
+    with \eqn{\pi_j} uniform over aligned variants and \eqn{\log W(0)=0}.
+  \item Normalise under a uniform prior over the \eqn{2^N} activation
+    configurations.
   \item Per-trait marginal: \eqn{P(\mathrm{trait}\,n\,\mathrm{causal}) =
     \sum_{c: c_n = 1} P(c \mid \mathrm{tuple})}.
 }
+
+The \eqn{2^N} activation space is a coherent post hoc model for a candidate
+credible-set event. It is especially useful in cross-population fine-mapping,
+where a proposed shared causal event may be causal or detectable in only a
+subset of populations because of differences in LD, allele frequency, sample
+size, or effect size.
+
+This activation space should be distinguished from the complete coloc-style
+sharing space. A complete colocalisation model also allows active traits to
+split into distinct causal groups. With inactive traits allowed, this is a
+partial-partition space of size Bell(\eqn{N+1}). In other words,
+SuSiEx-style activation asks which traits participate in one candidate
+event, whereas a complete coloc-style model asks how active traits are
+partitioned into one or more causal events.
+
+For two traits, the SuSiEx-style activation space contains
+\eqn{H(0,0)}, \eqn{H(1,0)}, \eqn{H(0,1)}, and \eqn{H(1,1)}. Coloc further
+separates the active state \eqn{H(1,1)} into two competing explanations:
+H3, where both traits are active but have distinct causal variants, and H4,
+where both traits share one causal variant.
+
 }
 
 \subsection{Coloc pairwise algorithm}{

--- a/man/susie_post_outcome_configuration.Rd
+++ b/man/susie_post_outcome_configuration.Rd
@@ -39,8 +39,9 @@ the function twice.}
 \item{cs_only}{Logical. If \code{TRUE} (default) only enumerate over CSs
 present in each fit's \code{$sets$cs}; if \code{FALSE} loop over all L
 rows of \code{$alpha}. Either way, effects whose entire alpha row is
-zero are skipped. When \code{TRUE}, every fit must carry a non-null
-\code{$sets$cs} or the function errors.}
+zero are skipped. When \code{TRUE}, trait views without credible sets
+are skipped with a warning; if fewer than two trait views remain, the
+function returns \code{NULL}.}
 
 \item{p1, p2, p12}{Coloc per-SNP causal priors: \code{p1} for trait 1
 alone, \code{p2} for trait 2 alone, \code{p12} for shared causal.
@@ -51,8 +52,10 @@ Defaults match \code{coloc::coloc.bf_bf}: \code{p1 = p2 = 1e-4},
 \item{...}{Currently ignored.}
 }
 \value{
-A list of class \code{"susie_post_outcome_configuration"} with
-exactly one of the following components, depending on \code{method}:
+\code{NULL} if fewer than two trait views are available for
+post-hoc analysis; otherwise a list of class
+\code{"susie_post_outcome_configuration"} with exactly one of the following
+components, depending on \code{method}:
 \describe{
   \item{\code{$susiex}}{(when \code{method = "susiex"}) A list of length
     equal to the number of CS tuples considered. Each element has

--- a/man/susie_post_outcome_configuration.Rd
+++ b/man/susie_post_outcome_configuration.Rd
@@ -8,7 +8,7 @@ susie_post_outcome_configuration(
   input,
   by = c("fit", "outcome"),
   outcome_names = NULL,
-  method = c("susiex", "coloc_pairwise"),
+  method = c("susiex", "coloc_pairwise", "mvsusie"),
   prob_thresh = 0.8,
   cs_only = TRUE,
   p1 = 1e-04,
@@ -29,9 +29,9 @@ susie_post_outcome_configuration(
 \code{trait_1}, \code{trait_2}, ... are used. If provided, its length must
 match the number of trait views after applying \code{by}.}
 
-\item{method}{Character scalar; one of \code{"susiex"} (default) or
-\code{"coloc_pairwise"}. Pick the analysis to run; for both, call
-the function twice.}
+\item{method}{Character scalar; one of \code{"susiex"} (default),
+\code{"coloc_pairwise"}, or \code{"mvsusie"}. Pick the analysis to run;
+for multiple analyses, call the function more than once.}
 
 \item{prob_thresh}{Per-trait marginal threshold for the convenience
 \code{$active} flags in the SuSiEx output. Default \code{0.8}.}
@@ -66,28 +66,35 @@ components, depending on \code{method}:
     A data.frame with one row per (trait1, trait2, l1, l2)
     combination, columns \code{trait1, trait2, l1, l2, hit1, hit2,
     PP.H0, PP.H1, PP.H2, PP.H3, PP.H4}.}
+  \item{\code{$mvsusie}}{(when \code{method = "mvsusie"}) A CS-level
+    data.frame for one multi-output \code{mvsusie} or \code{mfsusie}
+    fit. The table organizes mvSuSiE-native quantities: CS label,
+    single-effect index, sentinel hit, max PIP, overall log BF,
+    per-outcome log BF, and \code{single_effect_lfsr}.}
 }
 Pretty-print with \code{summary(out)}.
 }
 \description{
-Runs one of two complementary post-hoc analyses, selected by
+Runs one of three complementary post-hoc analyses, selected by
 \code{method}: \code{"susiex"} (default) for the SuSiEx \eqn{2^N}
 combinatorial enumeration, reporting posterior probabilities over
-binary causality patterns across the \eqn{N} input traits; or
+binary causality patterns across the \eqn{N} input traits;
 \code{"coloc_pairwise"} for the coloc pairwise ABF, reporting the
 five colocalisation hypothesis posteriors (H0/H1/H2/H3/H4) for every
-pair of traits. To get both, call the function twice and combine.
+pair of traits; or \code{"mvsusie"} for CS-level summaries
+from one multi-output mvSuSiE fit. To get multiple views, call the
+function more than once and combine.
 }
 \details{
-Two grouping modes are supported through the \code{by} argument:
+Three input organizations are supported:
 \describe{
-  \item{\code{"fit"}}{Each input fit contributes a single trait view.
+  \item{\code{by = "fit"}}{Each input fit contributes a single trait view.
     Multi-output fits (\code{mvsusie}, \code{mfsusie}) are kept whole: the
     trait's per-(CS, SNP) log Bayes factors are the joint composite
     stored on the fit as \code{lbf_variable}. Configuration enumeration
     loops over the cross-product \eqn{L_1 \times \dots \times L_N} of CS
     indices.}
-  \item{\code{"outcome"}}{Multi-output fits fan out into per-outcome views,
+  \item{\code{by = "outcome"}}{Multi-output fits fan out into per-outcome views,
     each with its own per-(CS, SNP) log Bayes factors read from
     \code{fit$lbf_variable_outcome} (an \eqn{L \times J \times R} or
     \eqn{L \times J \times M} array). All per-outcome views share the
@@ -95,6 +102,8 @@ Two grouping modes are supported through the \code{by} argument:
     reduces to a single index \eqn{l \in 1..L}. Single-output \code{susie}
     fits pass through unchanged. Requires \code{$lbf_variable_outcome} on the
     fit (set \code{attach_lbf_variable_outcome = TRUE} when fitting).}
+  \item{\code{method = "mvsusie"}}{One multi-output mvSuSiE fit is used
+    directly, and results are summarized at the CS/effect level.}
 }
 
 After SuSiE has been fit, the post-hoc step can answer two related

--- a/man/susie_post_outcome_configuration.Rd
+++ b/man/susie_post_outcome_configuration.Rd
@@ -105,7 +105,8 @@ questions:
     every trait pair and CS pair. It asks whether same-SNP evidence is
     stronger than distinct-causal evidence, represented by terms such as
     \eqn{\sum_{j \ne k}\exp(\ell_{1j}+\ell_{2k})}; this separates H3,
-    two distinct causal variants, from H4, one shared causal variant.}
+    two distinct causal variants, from H4, one shared causal variant.
+    Per-SNP log Bayes factors are aligned by variant name when available.}
 }
 
 \subsection{Two-trait example}{

--- a/man/susie_post_outcome_configuration.Rd
+++ b/man/susie_post_outcome_configuration.Rd
@@ -10,6 +10,7 @@ susie_post_outcome_configuration(
   outcome_names = NULL,
   method = c("susiex", "coloc_pairwise", "mvsusie"),
   prob_thresh = 0.8,
+  single_effect_lfsr_cutoff = 0.05,
   cs_only = TRUE,
   p1 = 1e-04,
   p2 = 1e-04,
@@ -35,6 +36,11 @@ for multiple analyses, call the function more than once.}
 
 \item{prob_thresh}{Per-trait marginal threshold for the convenience
 \code{$active} flags in the SuSiEx output. Default \code{0.8}.}
+
+\item{single_effect_lfsr_cutoff}{LFSR threshold used to flag mvSuSiE
+outcome-specific CS evidence in the \code{"mvsusie"} summary.
+The LFSR is read from \code{fit$lfsr} at each CS sentinel SNP.
+Default \code{0.05}.}
 
 \item{cs_only}{Logical. If \code{TRUE} (default) only enumerate over CSs
 present in each fit's \code{$sets$cs}; if \code{FALSE} loop over all L
@@ -66,11 +72,11 @@ components, depending on \code{method}:
     A data.frame with one row per (trait1, trait2, l1, l2)
     combination, columns \code{trait1, trait2, l1, l2, hit1, hit2,
     PP.H0, PP.H1, PP.H2, PP.H3, PP.H4}.}
-  \item{\code{$mvsusie}}{(when \code{method = "mvsusie"}) A CS-level
-    data.frame for one multi-output \code{mvsusie} or \code{mfsusie}
-    fit. The table organizes mvSuSiE-native quantities: CS label,
-    single-effect index, sentinel hit, max PIP, overall log BF,
-    per-outcome log BF, and \code{single_effect_lfsr}.}
+  \item{\code{$mvsusie}}{(when \code{method = "mvsusie"}) Summarizes one
+    multi-output \code{mvsusie} or \code{mfsusie} fit by CS, returning
+    \code{cs_summary}, \code{config_summary} (outcome log BF, sentinel
+    LFSR, cutoff flag), and \code{cs_variant_summary} (CS variant PIP and
+    outcome-specific LFSR).}
 }
 Pretty-print with \code{summary(out)}.
 }

--- a/man/susie_post_outcome_configuration.Rd
+++ b/man/susie_post_outcome_configuration.Rd
@@ -74,9 +74,9 @@ components, depending on \code{method}:
     PP.H0, PP.H1, PP.H2, PP.H3, PP.H4}.}
   \item{\code{$mvsusie}}{(when \code{method = "mvsusie"}) Summarizes one
     multi-output \code{mvsusie} or \code{mfsusie} fit by CS, returning
-    \code{cs_summary}, \code{config_summary} (outcome log BF, sentinel
-    LFSR, cutoff flag), and \code{cs_variant_summary} (CS variant PIP and
-    outcome-specific LFSR).}
+    \code{cs_summary} (CS purity and sentinel), \code{config_summary}
+    (outcome log BF, sentinel variant/LFSR, cutoff flag), and
+    \code{cs_variant_summary} (CS variant PIP and outcome-specific LFSR).}
 }
 Pretty-print with \code{summary(out)}.
 }

--- a/man/susie_post_outcome_configuration.Rd
+++ b/man/susie_post_outcome_configuration.Rd
@@ -8,7 +8,7 @@ susie_post_outcome_configuration(
   input,
   by = c("fit", "outcome"),
   outcome_names = NULL,
-  method = c("susiex", "coloc_pairwise", "mvsusie"),
+  method = c("susiex", "coloc_pairwise"),
   prob_thresh = 0.8,
   single_effect_lfsr_cutoff = 0.05,
   cs_only = TRUE,
@@ -31,16 +31,16 @@ susie_post_outcome_configuration(
 match the number of trait views after applying \code{by}.}
 
 \item{method}{Character scalar; one of \code{"susiex"} (default),
-\code{"coloc_pairwise"}, or \code{"mvsusie"}. Pick the analysis to run;
-for multiple analyses, call the function more than once.}
+or \code{"coloc_pairwise"}. Pick the analysis to run; for both analyses,
+call the function twice.}
 
 \item{prob_thresh}{Per-trait marginal threshold for the convenience
 \code{$active} flags in the SuSiEx output. Default \code{0.8}.}
 
-\item{single_effect_lfsr_cutoff}{LFSR threshold used to flag mvSuSiE
-outcome-specific CS evidence in the \code{"mvsusie"} summary.
-The LFSR is read from \code{fit$lfsr} at each CS sentinel SNP.
-Default \code{0.05}.}
+\item{single_effect_lfsr_cutoff}{LFSR threshold used to flag
+outcome-specific CS evidence when \code{method = "susiex"} is applied to
+one multi-output \code{mvsusie} or \code{mfsusie} fit. The LFSR is read
+from \code{fit$lfsr} at each CS sentinel SNP. Default \code{0.05}.}
 
 \item{cs_only}{Logical. If \code{TRUE} (default) only enumerate over CSs
 present in each fit's \code{$sets$cs}; if \code{FALSE} loop over all L
@@ -67,32 +67,30 @@ components, depending on \code{method}:
     equal to the number of CS tuples considered. Each element has
     components \code{config_probability} (binary trait-activation table
     with a \code{config_prob} column) and \code{activation_summary}
-    (CS-level post-hoc activation summary by trait).}
+    (CS-level post-hoc activation summary by trait). For one multi-output
+    \code{mvsusie} or \code{mfsusie} fit, each CS element instead combines
+    native CS summaries (\code{mvsusie_cs_summary}, \code{mvsusie_config_summary},
+    \code{mvsusie_cs_variant_summary}) with SuSiEx interpretation tables
+    (\code{susiex_config_probability},
+    \code{susiex_activation_summary}).}
   \item{\code{$coloc_pairwise}}{(when \code{method = "coloc_pairwise"})
     A data.frame with one row per (trait1, trait2, l1, l2)
     combination, columns \code{trait1, trait2, l1, l2, hit1, hit2,
     PP.H0, PP.H1, PP.H2, PP.H3, PP.H4}.}
-  \item{\code{$mvsusie}}{(when \code{method = "mvsusie"}) Summarizes one
-    multi-output \code{mvsusie} or \code{mfsusie} fit by CS, returning
-    \code{cs_summary} (CS purity and sentinel), \code{config_summary}
-    (outcome log BF, sentinel variant/LFSR, cutoff flag), and
-    \code{cs_variant_summary} (CS variant PIP and outcome-specific LFSR).}
 }
 Pretty-print with \code{summary(out)}.
 }
 \description{
-Runs one of three complementary post-hoc analyses, selected by
+Runs one of two complementary post-hoc analyses, selected by
 \code{method}: \code{"susiex"} (default) for the SuSiEx \eqn{2^N}
 combinatorial enumeration, reporting posterior probabilities over
 binary causality patterns across the \eqn{N} input traits;
 \code{"coloc_pairwise"} for the coloc pairwise ABF, reporting the
 five colocalisation hypothesis posteriors (H0/H1/H2/H3/H4) for every
-pair of traits; or \code{"mvsusie"} for CS-level summaries
-from one multi-output mvSuSiE fit. To get multiple views, call the
-function more than once and combine.
+pair of traits. To get both views, call the function twice and combine.
 }
 \details{
-Three input organizations are supported:
+Two input organizations are supported:
 \describe{
   \item{\code{by = "fit"}}{Each input fit contributes a single trait view.
     Multi-output fits (\code{mvsusie}, \code{mfsusie}) are kept whole: the
@@ -108,8 +106,6 @@ Three input organizations are supported:
     reduces to a single index \eqn{l \in 1..L}. Single-output \code{susie}
     fits pass through unchanged. Requires \code{$lbf_variable_outcome} on the
     fit (set \code{attach_lbf_variable_outcome = TRUE} when fitting).}
-  \item{\code{method = "mvsusie"}}{One multi-output mvSuSiE fit is used
-    directly, and results are summarized at the CS/effect level.}
 }
 
 After SuSiE has been fit, the post-hoc step can answer two related

--- a/tests/testthat/helper_coloc.R
+++ b/tests/testthat/helper_coloc.R
@@ -24,9 +24,14 @@ coloc_fit <- function(alpha, lbf, cs = list(L1 = 1L)) {
 }
 
 # Minimal hand-built mvsusie fit with a per-outcome log-BF array.
-coloc_mv_fit <- function(alpha, lbf, lbf_outcome, cs = list(L1 = 1L)) {
+coloc_mv_fit <- function(alpha, lbf, lbf_variable_outcome,
+                         cs = list(L1 = 1L), lbf_outcome = NULL,
+                         single_effect_lfsr = NULL, outcome_names = NULL) {
   structure(list(alpha = alpha, lbf_variable = lbf,
-                 lbf_variable_outcome = lbf_outcome,
+                 lbf_variable_outcome = lbf_variable_outcome,
+                 lbf_outcome = lbf_outcome,
+                 single_effect_lfsr = single_effect_lfsr,
+                 outcome_names = outcome_names,
                  sets = list(cs = cs)),
             class = "mvsusie")
 }

--- a/tests/testthat/test_post_outcome_configuration.R
+++ b/tests/testthat/test_post_outcome_configuration.R
@@ -155,6 +155,10 @@ test_that("entry point rejects malformed p1/p2/p12 priors", {
     susie_post_outcome_configuration(fit, method = "coloc_pairwise",
                                      p12 = NA_real_),
     "`p12` must be a single numeric")
+  expect_error(
+    susie_post_outcome_configuration(fit, method = "mvsusie",
+                                     single_effect_lfsr_cutoff = NA_real_),
+    "`single_effect_lfsr_cutoff` must be a single numeric")
 })
 
 test_that("method = 'susiex' returns tagged object with $susiex component", {
@@ -190,6 +194,16 @@ test_that("method = 'coloc_pairwise' returns tagged object with coloc df", {
   expect_equal(unname(rowSums(pp)), rep(1, nrow(pp)), tolerance = 1e-8)
 })
 
+test_that("method = 'coloc_pairwise' errors when named variants do not overlap", {
+  f1 <- coloc_fit(matrix(1, 1, 1, dimnames = list(NULL, "a")),
+                  matrix(2, 1, 1, dimnames = list(NULL, "a")))
+  f2 <- coloc_fit(matrix(1, 1, 1, dimnames = list(NULL, "b")),
+                  matrix(2, 1, 1, dimnames = list(NULL, "b")))
+  expect_error(
+    susie_post_outcome_configuration(list(f1, f2), method = "coloc_pairwise"),
+    "no overlapping variants")
+})
+
 test_that("method = 'mvsusie' returns a CS-level mvSuSiE summary table", {
   A <- matrix(0, 3, 4)
   A[1, 1] <- 1; A[2, 2] <- 1; A[3, 3] <- 1
@@ -207,6 +221,10 @@ test_that("method = 'mvsusie' returns a CS-level mvSuSiE summary table", {
                       lbf_outcome = lbf_out,
                       single_effect_lfsr = lfsr)
   fit$pip <- c(0.8, 0.1, 0.2, 0.9)
+  fit$lfsr <- matrix(c(0.001, 0.2,
+                       0.2,   0.2,
+                       0.2,   0.2,
+                       0.2,   0.003), nrow = 4, byrow = TRUE)
   fit$lbf <- c(10, 2, 5)
   fit$variable_names <- paste0("s", 1:4)
 
@@ -215,19 +233,44 @@ test_that("method = 'mvsusie' returns a CS-level mvSuSiE summary table", {
   expect_s3_class(res, "susie_post_outcome_configuration")
   expect_true("mvsusie" %in% names(res))
   expect_identical(attr(res, "method"), "mvsusie")
-  expect_s3_class(res$mvsusie, "data.frame")
-  expect_equal(res$mvsusie$cs, c("L3", "L1"))
-  expect_equal(res$mvsusie$single_effect, c(3L, 1L))
-  expect_equal(res$mvsusie$n_cs, c(2L, 1L))
-  expect_equal(res$mvsusie$hit, c("s4", "s1"))
-  expect_equal(res$mvsusie$maxPIP, c(0.9, 0.8))
-  expect_equal(res$mvsusie$lbf, c(5, 10))
-  expect_equal(res$mvsusie[["lbf_outcome.old"]], c(3, 4))
-  expect_equal(res$mvsusie[["lbf_outcome.new"]], c(0, -1))
-  expect_equal(res$mvsusie[["single_effect_lfsr.old"]], c(0.04, 0.01))
-  expect_equal(res$mvsusie[["single_effect_lfsr.new"]], c(0.5, 1))
-  expect_false("activation_summary" %in% names(res$mvsusie))
-  expect_false("posthoc_prob" %in% names(res$mvsusie))
+  expect_type(res$mvsusie, "list")
+  expect_named(res$mvsusie, c("L3", "L1"))
+  expect_named(res$mvsusie$L3,
+               c("cs_summary", "config_summary", "cs_variant_summary"))
+
+  expect_s3_class(res$mvsusie$L3$cs_summary, "data.frame")
+  expect_equal(res$mvsusie$L3$cs_summary$cs, "L3")
+  expect_equal(res$mvsusie$L3$cs_summary$single_effect, 3L)
+  expect_equal(res$mvsusie$L3$cs_summary$n_cs, 2L)
+  expect_equal(res$mvsusie$L3$cs_summary$hit, "s4")
+  expect_equal(res$mvsusie$L3$cs_summary$maxPIP, 0.9)
+  expect_equal(res$mvsusie$L3$cs_summary$lbf, 5)
+  expect_equal(res$mvsusie$L3$cs_summary$n_lfsr_pass, 1L)
+
+  expect_s3_class(res$mvsusie$L3$config_summary, "data.frame")
+  expect_named(res$mvsusie$L3$config_summary,
+               c("outcome", "lbf_outcome", "sentinel_lfsr", "lfsr_pass"))
+  expect_equal(res$mvsusie$L3$config_summary$outcome, c("old", "new"))
+  expect_equal(res$mvsusie$L3$config_summary$lbf_outcome, c(3, 0))
+  expect_equal(res$mvsusie$L3$config_summary$sentinel_lfsr, c(0.2, 0.003))
+  expect_equal(res$mvsusie$L3$config_summary$lfsr_pass, c(FALSE, TRUE))
+  expect_identical(attr(res, "single_effect_lfsr_cutoff"), 0.05)
+  expect_false("activation_summary" %in% names(res$mvsusie$L3))
+  expect_false("posthoc_prob" %in% names(res$mvsusie$L3))
+  expect_false("single_effect_lfsr" %in%
+                 colnames(res$mvsusie$L3$config_summary))
+
+  expect_s3_class(res$mvsusie$L3$cs_variant_summary, "data.frame")
+  expect_named(res$mvsusie$L3$cs_variant_summary,
+               c("variant", "pip", "lfsr_old", "lfsr_new"))
+  expect_equal(res$mvsusie$L3$cs_variant_summary$variant, c("s3", "s4"))
+  expect_equal(res$mvsusie$L3$cs_variant_summary$pip, c(0.2, 0.9))
+  expect_equal(res$mvsusie$L3$cs_variant_summary$lfsr_old, c(0.2, 0.2))
+  expect_equal(res$mvsusie$L3$cs_variant_summary$lfsr_new, c(0.2, 0.003))
+
+  strict <- susie_post_outcome_configuration(
+    fit, method = "mvsusie", single_effect_lfsr_cutoff = 0.01)
+  expect_equal(strict$mvsusie$L3$config_summary$lfsr_pass, c(FALSE, TRUE))
 })
 
 test_that("method = 'mvsusie' can compute lbf_outcome from alpha-weighted outcome LBFs", {
@@ -244,10 +287,132 @@ test_that("method = 'mvsusie' can compute lbf_outcome from alpha-weighted outcom
 
   res <- susie_post_outcome_configuration(fit, method = "mvsusie")
 
-  expect_equal(res$mvsusie[["lbf_outcome.t1"]], c(5, 3))
-  expect_equal(res$mvsusie[["lbf_outcome.t2"]], c(7, 5))
+  expect_equal(res$mvsusie$L1$config_summary$lbf_outcome, c(5, 7))
+  expect_equal(res$mvsusie$L2$config_summary$lbf_outcome, c(3, 5))
   expect_true(all(c("cs", "single_effect", "hit", "maxPIP") %in%
-                    colnames(res$mvsusie)))
+                    colnames(res$mvsusie$L1$cs_summary)))
+})
+
+test_that("method = 'mvsusie' covers input and missing-data edge cases", {
+  A <- matrix(c(1, 0), 1, 2)
+  LV <- matrix(0, 1, 2)
+  fit <- coloc_mv_fit(A, LV, array(0, dim = c(1, 2, 2)),
+                      cs = list(L1 = 1L),
+                      lbf_outcome = as.data.frame(matrix(c(4, 2), 1, 2)))
+  fit$pip <- c(0.7, 0.2)
+  fit$lfsr <- data.frame(old = c(0.01, 0.2), new = c(0.2, 0.03))
+  fit$lbf <- 4
+  fit$variable_names <- c("s1", "s2")
+
+  res <- susie_post_outcome_configuration(
+    list(fit), method = "mvsusie", outcome_names = c("old", "new"))
+  expect_equal(res$mvsusie$L1$config_summary$outcome, c("old", "new"))
+  expect_equal(res$mvsusie$L1$config_summary$sentinel_lfsr, c(0.01, 0.2))
+
+  expect_error(
+    susie_post_outcome_configuration(list(fit, fit), method = "mvsusie"),
+    "requires one multi-output fit")
+  expect_error(
+    susie_post_outcome_configuration(fit, method = "mvsusie",
+                                     outcome_names = c("old", "")),
+    "outcome_names")
+
+  one_outcome <- fit
+  one_outcome$lbf_outcome <- matrix(1, 1, 1)
+  one_outcome$lfsr <- matrix(c(0.1, 0.2), 2, 1)
+  expect_message(
+    expect_null(susie_post_outcome_configuration(one_outcome,
+                                                 method = "mvsusie")),
+    "Fewer than two outcomes")
+
+  no_cs <- fit
+  no_cs$sets$cs <- list()
+  expect_message(
+    expect_null(susie_post_outcome_configuration(no_cs, method = "mvsusie")),
+    "No credible sets")
+
+  bad_lbf <- fit
+  bad_lbf$lbf_outcome <- matrix(1, 2, 2)
+  expect_error(
+    susie_post_outcome_configuration(bad_lbf, method = "mvsusie"),
+    "one row per")
+
+  missing_lbf <- fit
+  missing_lbf$lbf_outcome <- NULL
+  missing_lbf$lbf_variable_outcome <- NULL
+  expect_error(
+    susie_post_outcome_configuration(missing_lbf, method = "mvsusie"),
+    "requires.*lbf_outcome")
+
+  malformed_lbf <- fit
+  malformed_lbf$lbf_outcome <- NULL
+  malformed_lbf$lbf_variable_outcome <- array(0, dim = c(2, 2, 2))
+  expect_error(
+    susie_post_outcome_configuration(malformed_lbf, method = "mvsusie"),
+    "must be L x J")
+})
+
+test_that("method = 'mvsusie' covers CS member edge cases", {
+  A <- matrix(c(1, 0), 1, 2)
+  LV <- matrix(0, 1, 2)
+  fit <- coloc_mv_fit(A, LV, array(0, dim = c(1, 2, 2)),
+                      cs = list(L1 = c("s1", "s2")),
+                      lbf_outcome = matrix(c(4, 2), 1, 2))
+  fit$pip <- c(0.7, 0.2)
+  fit$lfsr <- matrix(c(0.01, 0.2,
+                       0.2,  0.03), 2, 2, byrow = TRUE)
+  fit$lbf <- 4
+  fit$variable_names <- c("s1", "s2")
+
+  empty_hit <- mvsusie_cs_hit(
+    structure(list(sets = list(cs = NULL)), class = "mvsusie"),
+    label = "L1", idx = 1L, variable_names = c("s1", "s2"))
+  expect_equal(empty_hit$n_cs, 0L)
+  expect_true(is.na(empty_hit$hit))
+
+  missing_hit <- mvsusie_cs_hit(fit, label = "missing", idx = 99L,
+                                variable_names = c("s1", "s2"))
+  expect_equal(missing_hit$n_cs, 0L)
+  expect_true(is.na(missing_hit$hit))
+
+  res <- susie_post_outcome_configuration(fit, method = "mvsusie")
+  expect_equal(res$mvsusie$L1$cs_variant_summary$variant, c("s1", "s2"))
+  expect_equal(res$mvsusie$L1$cs_variant_summary$pip, c(0.7, 0.2))
+
+  unnamed_cs <- fit
+  unnamed_cs$sets$cs <- list(2L)
+  attr(unnamed_cs$sets$cs, "cs_idx") <- 1L
+  res_unnamed <- susie_post_outcome_configuration(unnamed_cs,
+                                                  method = "mvsusie")
+  expect_equal(res_unnamed$mvsusie$L1$cs_summary$hit, "s2")
+
+  no_pip <- fit
+  no_pip$pip <- NULL
+  res_no_pip <- susie_post_outcome_configuration(no_pip, method = "mvsusie")
+  expect_true(all(is.na(res_no_pip$mvsusie$L1$cs_variant_summary$pip)))
+  expect_true(all(is.na(res_no_pip$mvsusie$L1$cs_summary$hit)))
+
+  bad_members <- fit
+  bad_members$sets$cs <- list(L1 = 99L)
+  res_bad_members <- susie_post_outcome_configuration(bad_members,
+                                                      method = "mvsusie")
+  expect_equal(res_bad_members$mvsusie$L1$cs_summary$n_cs, 1L)
+  expect_equal(nrow(res_bad_members$mvsusie$L1$cs_variant_summary), 0L)
+
+  zero_alpha <- coloc_mv_fit(matrix(c(0, 0,
+                                      0, 1), 2, 2, byrow = TRUE),
+                             matrix(0, 2, 2),
+                             array(0, dim = c(2, 2, 2)),
+                             cs = list(L1 = 1L, L2 = 2L),
+                             lbf_outcome = matrix(c(1, 2,
+                                                    3, 4), 2, 2,
+                                                  byrow = TRUE))
+  zero_alpha$pip <- c(0.1, 0.9)
+  zero_alpha$lfsr <- fit$lfsr
+  zero_alpha$variable_names <- c("s1", "s2")
+  res_zero_alpha <- susie_post_outcome_configuration(zero_alpha,
+                                                     method = "mvsusie")
+  expect_named(res_zero_alpha$mvsusie, "L2")
 })
 
 test_that("entry point returns NULL for a single fit", {
@@ -269,6 +434,42 @@ test_that("is_susie_fit recognises susie / mvsusie / mfsusie only", {
   expect_false(is_susie_fit(structure(list(), class = "lm")))
   expect_false(is_susie_fit(list()))
   expect_false(is_susie_fit(42))
+})
+
+test_that("internal helpers cover defensive display branches", {
+  expect_equal(view_cs_label(list(sets_cs = NULL), 2L), "L2")
+  expect_equal(view_cs_label(list(sets_cs = list(1L)), 1L), "L1")
+
+  views <- list(
+    list(name = "a", lbf = matrix(1, 1, 1)),
+    list(name = "b", lbf = matrix(1, 1, 1))
+  )
+  expect_equal(
+    .susiex_config_logbf(c(1L, 1L), c(1L, 1L), views,
+                         variant_keys = list("a_only", "b_only"),
+                         variant_space_size = 2L),
+    -Inf
+  )
+
+  expect_identical(.organize_susiex_output(list("plain"))[[1]], "plain")
+
+  tup_fallback <- coloc_tuple(c("a", "b"), cs_indices = c(1, 2),
+                              marginal_prob = c(0.9, 0.8))
+  names(tup_fallback$cs_indices) <- NULL
+  tup_fallback$cs_labels <- setNames(c("L1", "L2"), c("a", "b"))
+  org_fallback <- .organize_susiex_output(list(tup_fallback))[[1]]
+  expect_named(org_fallback$activation_summary, c("a", "b"))
+
+  tup_no_labels <- coloc_tuple(c("a", "b"), cs_indices = c(1, 2),
+                               marginal_prob = c(0.9, 0.8))
+  tup_no_labels$cs_labels <- NULL
+  org_no_labels <- .organize_susiex_output(list(tup_no_labels))[[1]]
+  expect_equal(as.character(org_no_labels$activation_summary["cs_indices", ]),
+               c("L1", "L2"))
+
+  wrapped <- list(shown = FALSE)
+  attr(wrapped, "raw") <- list(shown = TRUE)
+  expect_equal(.susiex_raw(wrapped), list(shown = TRUE))
 })
 
 # ---- normalise_to_views() --------------------------------------------------

--- a/tests/testthat/test_post_outcome_configuration.R
+++ b/tests/testthat/test_post_outcome_configuration.R
@@ -156,7 +156,7 @@ test_that("entry point rejects malformed p1/p2/p12 priors", {
                                      p12 = NA_real_),
     "`p12` must be a single numeric")
   expect_error(
-    susie_post_outcome_configuration(fit, method = "mvsusie",
+    susie_post_outcome_configuration(fit, method = "susiex",
                                      single_effect_lfsr_cutoff = NA_real_),
     "`single_effect_lfsr_cutoff` must be a single numeric")
 })
@@ -204,7 +204,7 @@ test_that("method = 'coloc_pairwise' errors when named variants do not overlap",
     "no overlapping variants")
 })
 
-test_that("method = 'mvsusie' returns a CS-level mvSuSiE summary table", {
+test_that("method = 'susiex' returns mvSuSiE CS summaries with SuSiEx activation", {
   A <- matrix(0, 3, 4)
   A[1, 1] <- 1; A[2, 2] <- 1; A[3, 3] <- 1
   LV <- matrix(0, 3, 4)
@@ -234,55 +234,73 @@ test_that("method = 'mvsusie' returns a CS-level mvSuSiE summary table", {
     row.names = c("L3", "L1")
   )
 
-  res <- susie_post_outcome_configuration(fit, method = "mvsusie")
+  res <- susie_post_outcome_configuration(fit, method = "susiex")
 
   expect_s3_class(res, "susie_post_outcome_configuration")
-  expect_true("mvsusie" %in% names(res))
-  expect_identical(attr(res, "method"), "mvsusie")
-  expect_type(res$mvsusie, "list")
-  expect_named(res$mvsusie, c("L3", "L1"))
-  expect_named(res$mvsusie$L3,
-               c("cs_summary", "config_summary", "cs_variant_summary"))
+  expect_true("susiex" %in% names(res))
+  expect_false("mvsusie" %in% names(res))
+  expect_identical(attr(res, "method"), "susiex")
+  expect_type(res$susiex, "list")
+  expect_named(res$susiex, c("L3", "L1"))
+  expect_named(res$susiex$L3,
+               c("mvsusie_cs_summary", "mvsusie_config_summary", "mvsusie_cs_variant_summary",
+                 "susiex_config_probability", "susiex_activation_summary"))
 
-  expect_s3_class(res$mvsusie$L3$cs_summary, "data.frame")
-  expect_equal(res$mvsusie$L3$cs_summary$cs, "L3")
-  expect_equal(res$mvsusie$L3$cs_summary$n_variant, 2L)
-  expect_equal(res$mvsusie$L3$cs_summary$purity, 0.77)
-  expect_equal(res$mvsusie$L3$cs_summary$hit, "s4")
-  expect_equal(res$mvsusie$L3$cs_summary$maxPIP, 0.9)
-  expect_equal(res$mvsusie$L3$cs_summary$lbf, 5)
-  expect_equal(res$mvsusie$L3$cs_summary$n_lfsr_outcome, 1L)
+  expect_s3_class(res$susiex$L3$mvsusie_cs_summary, "data.frame")
+  expect_equal(res$susiex$L3$mvsusie_cs_summary$cs, "L3")
+  expect_equal(res$susiex$L3$mvsusie_cs_summary$n_variant, 2L)
+  expect_equal(res$susiex$L3$mvsusie_cs_summary$purity, 0.77)
+  expect_equal(res$susiex$L3$mvsusie_cs_summary$hit, "s4")
+  expect_equal(res$susiex$L3$mvsusie_cs_summary$maxPIP, 0.9)
+  expect_equal(res$susiex$L3$mvsusie_cs_summary$lbf, 5)
+  expect_equal(res$susiex$L3$mvsusie_cs_summary$n_lfsr_outcome, 1L)
 
-  expect_s3_class(res$mvsusie$L3$config_summary, "data.frame")
-  expect_named(res$mvsusie$L3$config_summary,
+  expect_s3_class(res$susiex$L3$mvsusie_config_summary, "data.frame")
+  expect_named(res$susiex$L3$mvsusie_config_summary,
                c("outcome", "lbf_outcome", "sentinel_variant",
                  "sentinel_lfsr", "lfsr_pass", "lfsr_cutoff"))
-  expect_equal(res$mvsusie$L3$config_summary$outcome, c("old", "new"))
-  expect_equal(res$mvsusie$L3$config_summary$lbf_outcome, c(3, 0))
-  expect_equal(res$mvsusie$L3$config_summary$sentinel_variant, c("s4", "s4"))
-  expect_equal(res$mvsusie$L3$config_summary$sentinel_lfsr, c(0.2, 0.003))
-  expect_equal(res$mvsusie$L3$config_summary$lfsr_pass, c(FALSE, TRUE))
-  expect_equal(res$mvsusie$L3$config_summary$lfsr_cutoff, c(0.05, 0.05))
+  expect_equal(res$susiex$L3$mvsusie_config_summary$outcome, c("old", "new"))
+  expect_equal(res$susiex$L3$mvsusie_config_summary$lbf_outcome, c(3, 0))
+  expect_equal(res$susiex$L3$mvsusie_config_summary$sentinel_variant, c("s4", "s4"))
+  expect_equal(res$susiex$L3$mvsusie_config_summary$sentinel_lfsr, c(0.2, 0.003))
+  expect_equal(res$susiex$L3$mvsusie_config_summary$lfsr_pass, c(FALSE, TRUE))
+  expect_equal(res$susiex$L3$mvsusie_config_summary$lfsr_cutoff, c(0.05, 0.05))
   expect_identical(attr(res, "single_effect_lfsr_cutoff"), 0.05)
-  expect_false("activation_summary" %in% names(res$mvsusie$L3))
-  expect_false("posthoc_prob" %in% names(res$mvsusie$L3))
+  expect_false("activation_summary" %in% names(res$susiex$L3))
+  expect_true("susiex_activation_summary" %in% names(res$susiex$L3))
+  expect_false("posthoc_prob" %in% names(res$susiex$L3))
   expect_false("single_effect_lfsr" %in%
-                 colnames(res$mvsusie$L3$config_summary))
+                 colnames(res$susiex$L3$mvsusie_config_summary))
 
-  expect_s3_class(res$mvsusie$L3$cs_variant_summary, "data.frame")
-  expect_named(res$mvsusie$L3$cs_variant_summary,
+  expect_s3_class(res$susiex$L3$mvsusie_cs_variant_summary, "data.frame")
+  expect_named(res$susiex$L3$mvsusie_cs_variant_summary,
                c("variant", "pip", "lfsr_old", "lfsr_new"))
-  expect_equal(res$mvsusie$L3$cs_variant_summary$variant, c("s3", "s4"))
-  expect_equal(res$mvsusie$L3$cs_variant_summary$pip, c(0.2, 0.9))
-  expect_equal(res$mvsusie$L3$cs_variant_summary$lfsr_old, c(0.2, 0.2))
-  expect_equal(res$mvsusie$L3$cs_variant_summary$lfsr_new, c(0.2, 0.003))
+  expect_equal(res$susiex$L3$mvsusie_cs_variant_summary$variant, c("s3", "s4"))
+  expect_equal(res$susiex$L3$mvsusie_cs_variant_summary$pip, c(0.2, 0.9))
+  expect_equal(res$susiex$L3$mvsusie_cs_variant_summary$lfsr_old, c(0.2, 0.2))
+  expect_equal(res$susiex$L3$mvsusie_cs_variant_summary$lfsr_new, c(0.2, 0.003))
+  expect_s3_class(res$susiex$L3$susiex_config_probability, "data.frame")
+  expect_named(res$susiex$L3$susiex_config_probability,
+               c("old", "new", "config_prob"))
+  expect_equal(nrow(res$susiex$L3$susiex_config_probability), 4L)
+  expect_s3_class(res$susiex$L3$susiex_activation_summary, "data.frame")
+  expect_named(res$susiex$L3$susiex_activation_summary, c("old", "new"))
+  expect_equal(
+    rownames(res$susiex$L3$susiex_activation_summary),
+    c("cs_indices", "logBF_trait", "posthoc_prob", "active"))
+  expect_equal(
+    as.character(res$susiex$L3$susiex_activation_summary["cs_indices", ]),
+    c("L3", "L3"))
+  expect_named(attr(res$susiex$L3, "raw"),
+               c("cs_indices", "cs_labels", "logBF_trait", "configs",
+                 "config_prob", "marginal_prob", "active"))
 
   strict <- susie_post_outcome_configuration(
-    fit, method = "mvsusie", single_effect_lfsr_cutoff = 0.01)
-  expect_equal(strict$mvsusie$L3$config_summary$lfsr_pass, c(FALSE, TRUE))
+    fit, method = "susiex", single_effect_lfsr_cutoff = 0.01)
+  expect_equal(strict$susiex$L3$mvsusie_config_summary$lfsr_pass, c(FALSE, TRUE))
 })
 
-test_that("method = 'mvsusie' can compute lbf_outcome from alpha-weighted outcome LBFs", {
+test_that("method = 'susiex' can compute lbf_outcome from alpha-weighted outcome LBFs", {
   A <- matrix(c(0.25, 0.75,
                 1.00, 0.00), nrow = 2, byrow = TRUE)
   LV <- matrix(0, 2, 2)
@@ -294,15 +312,38 @@ test_that("method = 'mvsusie' can compute lbf_outcome from alpha-weighted outcom
   arr[2, , 2] <- c(5, 7)
   fit <- coloc_mv_fit(A, LV, arr, cs = list(L1 = 1L, L2 = 2L))
 
-  res <- susie_post_outcome_configuration(fit, method = "mvsusie")
+  res <- susie_post_outcome_configuration(fit, method = "susiex")
 
-  expect_equal(res$mvsusie$L1$config_summary$lbf_outcome, c(5, 7))
-  expect_equal(res$mvsusie$L2$config_summary$lbf_outcome, c(3, 5))
+  expect_equal(res$susiex$L1$mvsusie_config_summary$lbf_outcome, c(5, 7))
+  expect_equal(res$susiex$L2$mvsusie_config_summary$lbf_outcome, c(3, 5))
   expect_true(all(c("cs", "n_variant", "purity", "hit", "maxPIP") %in%
-                    colnames(res$mvsusie$L1$cs_summary)))
+                    colnames(res$susiex$L1$mvsusie_cs_summary)))
 })
 
-test_that("method = 'mvsusie' covers input and missing-data edge cases", {
+test_that("method = 'susiex' handles mfsusie with the multi-output contract", {
+  fit <- coloc_mv_fit(
+    alpha = matrix(c(1, 0), 1, 2),
+    lbf = matrix(c(2, 0), 1, 2),
+    lbf_variable_outcome = array(c(4, 0, 5, 0), dim = c(1, 2, 2),
+                                 dimnames = list(NULL, c("s1", "s2"),
+                                                 c("old", "new"))),
+    cs = list(L1 = 1L)
+  )
+  class(fit) <- "mfsusie"
+  fit$pip <- c(0.8, 0.1)
+  fit$lfsr <- matrix(c(0.01, 0.02,
+                       0.2,  0.2), nrow = 2, byrow = TRUE)
+  fit$variable_names <- c("s1", "s2")
+
+  res <- susie_post_outcome_configuration(fit, method = "susiex")
+
+  expect_true("susiex" %in% names(res))
+  expect_named(res$susiex, "L1")
+  expect_named(res$susiex$L1$susiex_activation_summary, c("old", "new"))
+  expect_equal(nrow(res$susiex$L1$susiex_config_probability), 4L)
+})
+
+test_that("method = 'susiex' covers input and missing-data edge cases", {
   A <- matrix(c(1, 0), 1, 2)
   LV <- matrix(0, 1, 2)
   fit <- coloc_mv_fit(A, LV, array(0, dim = c(1, 2, 2)),
@@ -314,15 +355,16 @@ test_that("method = 'mvsusie' covers input and missing-data edge cases", {
   fit$variable_names <- c("s1", "s2")
 
   res <- susie_post_outcome_configuration(
-    list(fit), method = "mvsusie", outcome_names = c("old", "new"))
-  expect_equal(res$mvsusie$L1$config_summary$outcome, c("old", "new"))
-  expect_equal(res$mvsusie$L1$config_summary$sentinel_lfsr, c(0.01, 0.2))
+    list(fit), method = "susiex", outcome_names = c("old", "new"))
+  expect_equal(res$susiex$L1$mvsusie_config_summary$outcome, c("old", "new"))
+  expect_equal(res$susiex$L1$mvsusie_config_summary$sentinel_lfsr, c(0.01, 0.2))
+  expect_named(res$susiex$L1$susiex_activation_summary, c("old", "new"))
 
   expect_error(
-    susie_post_outcome_configuration(list(fit, fit), method = "mvsusie"),
-    "requires one multi-output fit")
+    susie_post_outcome_configuration(fit, method = "mvsusie"),
+    "'arg' should be one of")
   expect_error(
-    susie_post_outcome_configuration(fit, method = "mvsusie",
+    susie_post_outcome_configuration(fit, method = "susiex",
                                      outcome_names = c("old", "")),
     "outcome_names")
 
@@ -331,37 +373,37 @@ test_that("method = 'mvsusie' covers input and missing-data edge cases", {
   one_outcome$lfsr <- matrix(c(0.1, 0.2), 2, 1)
   expect_message(
     expect_null(susie_post_outcome_configuration(one_outcome,
-                                                 method = "mvsusie")),
+                                                 method = "susiex")),
     "Fewer than two outcomes")
 
   no_cs <- fit
   no_cs$sets$cs <- list()
   expect_message(
-    expect_null(susie_post_outcome_configuration(no_cs, method = "mvsusie")),
+    expect_null(susie_post_outcome_configuration(no_cs, method = "susiex")),
     "No credible sets")
 
   bad_lbf <- fit
   bad_lbf$lbf_outcome <- matrix(1, 2, 2)
   expect_error(
-    susie_post_outcome_configuration(bad_lbf, method = "mvsusie"),
+    susie_post_outcome_configuration(bad_lbf, method = "susiex"),
     "one row per")
 
   missing_lbf <- fit
   missing_lbf$lbf_outcome <- NULL
   missing_lbf$lbf_variable_outcome <- NULL
   expect_error(
-    susie_post_outcome_configuration(missing_lbf, method = "mvsusie"),
+    susie_post_outcome_configuration(missing_lbf, method = "susiex"),
     "requires.*lbf_outcome")
 
   malformed_lbf <- fit
   malformed_lbf$lbf_outcome <- NULL
   malformed_lbf$lbf_variable_outcome <- array(0, dim = c(2, 2, 2))
   expect_error(
-    susie_post_outcome_configuration(malformed_lbf, method = "mvsusie"),
+    susie_post_outcome_configuration(malformed_lbf, method = "susiex"),
     "must be L x J")
 })
 
-test_that("method = 'mvsusie' covers CS member edge cases", {
+test_that("method = 'susiex' covers CS member edge cases", {
   A <- matrix(c(1, 0), 1, 2)
   LV <- matrix(0, 1, 2)
   fit <- coloc_mv_fit(A, LV, array(0, dim = c(1, 2, 2)),
@@ -384,10 +426,10 @@ test_that("method = 'mvsusie' covers CS member edge cases", {
   expect_equal(missing_hit$n_cs, 0L)
   expect_true(is.na(missing_hit$hit))
 
-  res <- susie_post_outcome_configuration(fit, method = "mvsusie")
-  expect_equal(res$mvsusie$L1$cs_variant_summary$variant, c("s1", "s2"))
-  expect_equal(res$mvsusie$L1$cs_variant_summary$pip, c(0.7, 0.2))
-  expect_true(is.na(res$mvsusie$L1$cs_summary$purity))
+  res <- susie_post_outcome_configuration(fit, method = "susiex")
+  expect_equal(res$susiex$L1$mvsusie_cs_variant_summary$variant, c("s1", "s2"))
+  expect_equal(res$susiex$L1$mvsusie_cs_variant_summary$pip, c(0.7, 0.2))
+  expect_true(is.na(res$susiex$L1$mvsusie_cs_summary$purity))
 
   fit$sets$purity <- matrix(0.61, nrow = 1)
   expect_equal(mvsusie_cs_purity(fit, label = "L1", idx = 1L), 0.61)
@@ -398,22 +440,22 @@ test_that("method = 'mvsusie' covers CS member edge cases", {
   unnamed_cs$sets$purity <- data.frame(min.abs.corr = 0.42)
   attr(unnamed_cs$sets$cs, "cs_idx") <- 1L
   res_unnamed <- susie_post_outcome_configuration(unnamed_cs,
-                                                  method = "mvsusie")
-  expect_equal(res_unnamed$mvsusie$L1$cs_summary$hit, "s2")
-  expect_equal(res_unnamed$mvsusie$L1$cs_summary$purity, 0.42)
+                                                  method = "susiex")
+  expect_equal(res_unnamed$susiex$L1$mvsusie_cs_summary$hit, "s2")
+  expect_equal(res_unnamed$susiex$L1$mvsusie_cs_summary$purity, 0.42)
 
   no_pip <- fit
   no_pip$pip <- NULL
-  res_no_pip <- susie_post_outcome_configuration(no_pip, method = "mvsusie")
-  expect_true(all(is.na(res_no_pip$mvsusie$L1$cs_variant_summary$pip)))
-  expect_true(all(is.na(res_no_pip$mvsusie$L1$cs_summary$hit)))
+  res_no_pip <- susie_post_outcome_configuration(no_pip, method = "susiex")
+  expect_true(all(is.na(res_no_pip$susiex$L1$mvsusie_cs_variant_summary$pip)))
+  expect_true(all(is.na(res_no_pip$susiex$L1$mvsusie_cs_summary$hit)))
 
   bad_members <- fit
   bad_members$sets$cs <- list(L1 = 99L)
   res_bad_members <- susie_post_outcome_configuration(bad_members,
-                                                      method = "mvsusie")
-  expect_equal(res_bad_members$mvsusie$L1$cs_summary$n_variant, 1L)
-  expect_equal(nrow(res_bad_members$mvsusie$L1$cs_variant_summary), 0L)
+                                                      method = "susiex")
+  expect_equal(res_bad_members$susiex$L1$mvsusie_cs_summary$n_variant, 1L)
+  expect_equal(nrow(res_bad_members$susiex$L1$mvsusie_cs_variant_summary), 0L)
 
   zero_alpha <- coloc_mv_fit(matrix(c(0, 0,
                                       0, 1), 2, 2, byrow = TRUE),
@@ -427,8 +469,8 @@ test_that("method = 'mvsusie' covers CS member edge cases", {
   zero_alpha$lfsr <- fit$lfsr
   zero_alpha$variable_names <- c("s1", "s2")
   res_zero_alpha <- susie_post_outcome_configuration(zero_alpha,
-                                                     method = "mvsusie")
-  expect_named(res_zero_alpha$mvsusie, "L2")
+                                                     method = "susiex")
+  expect_named(res_zero_alpha$susiex, "L2")
 })
 
 test_that("entry point returns NULL for a single fit", {
@@ -1046,7 +1088,12 @@ test_that("by = 'outcome' on an mvsusie runs SuSiEx per-outcome on the diagonal"
                                           by = "outcome")
   # 3 outcome views => configs over 2^3 = 8 patterns; diagonal of 2 CSs => 2.
   expect_length(res$susiex, 2L)
-  expect_equal(nrow(res$susiex[[1]]$config_probability), 8L)
+  expect_named(res$susiex[[1]],
+               c("mvsusie_cs_summary", "mvsusie_config_summary", "mvsusie_cs_variant_summary",
+                 "susiex_config_probability", "susiex_activation_summary"))
+  expect_equal(nrow(res$susiex[[1]]$susiex_config_probability), 8L)
+  expect_named(res$susiex[[1]]$susiex_activation_summary,
+               c("o1", "o2", "o3"))
   expect_equal(unname(attr(res$susiex[[1]], "raw")$cs_indices),
                c(1L, 1L, 1L))
   expect_equal(unname(attr(res$susiex[[2]], "raw")$cs_indices),

--- a/tests/testthat/test_post_outcome_configuration.R
+++ b/tests/testthat/test_post_outcome_configuration.R
@@ -227,6 +227,12 @@ test_that("method = 'mvsusie' returns a CS-level mvSuSiE summary table", {
                        0.2,   0.003), nrow = 4, byrow = TRUE)
   fit$lbf <- c(10, 2, 5)
   fit$variable_names <- paste0("s", 1:4)
+  fit$sets$purity <- data.frame(
+    min.abs.corr = c(0.77, 0.91),
+    mean.abs.corr = c(0.84, 0.91),
+    median.abs.corr = c(0.84, 0.91),
+    row.names = c("L3", "L1")
+  )
 
   res <- susie_post_outcome_configuration(fit, method = "mvsusie")
 
@@ -240,20 +246,23 @@ test_that("method = 'mvsusie' returns a CS-level mvSuSiE summary table", {
 
   expect_s3_class(res$mvsusie$L3$cs_summary, "data.frame")
   expect_equal(res$mvsusie$L3$cs_summary$cs, "L3")
-  expect_equal(res$mvsusie$L3$cs_summary$single_effect, 3L)
-  expect_equal(res$mvsusie$L3$cs_summary$n_cs, 2L)
+  expect_equal(res$mvsusie$L3$cs_summary$n_variant, 2L)
+  expect_equal(res$mvsusie$L3$cs_summary$purity, 0.77)
   expect_equal(res$mvsusie$L3$cs_summary$hit, "s4")
   expect_equal(res$mvsusie$L3$cs_summary$maxPIP, 0.9)
   expect_equal(res$mvsusie$L3$cs_summary$lbf, 5)
-  expect_equal(res$mvsusie$L3$cs_summary$n_lfsr_pass, 1L)
+  expect_equal(res$mvsusie$L3$cs_summary$n_lfsr_outcome, 1L)
 
   expect_s3_class(res$mvsusie$L3$config_summary, "data.frame")
   expect_named(res$mvsusie$L3$config_summary,
-               c("outcome", "lbf_outcome", "sentinel_lfsr", "lfsr_pass"))
+               c("outcome", "lbf_outcome", "sentinel_variant",
+                 "sentinel_lfsr", "lfsr_pass", "lfsr_cutoff"))
   expect_equal(res$mvsusie$L3$config_summary$outcome, c("old", "new"))
   expect_equal(res$mvsusie$L3$config_summary$lbf_outcome, c(3, 0))
+  expect_equal(res$mvsusie$L3$config_summary$sentinel_variant, c("s4", "s4"))
   expect_equal(res$mvsusie$L3$config_summary$sentinel_lfsr, c(0.2, 0.003))
   expect_equal(res$mvsusie$L3$config_summary$lfsr_pass, c(FALSE, TRUE))
+  expect_equal(res$mvsusie$L3$config_summary$lfsr_cutoff, c(0.05, 0.05))
   expect_identical(attr(res, "single_effect_lfsr_cutoff"), 0.05)
   expect_false("activation_summary" %in% names(res$mvsusie$L3))
   expect_false("posthoc_prob" %in% names(res$mvsusie$L3))
@@ -289,7 +298,7 @@ test_that("method = 'mvsusie' can compute lbf_outcome from alpha-weighted outcom
 
   expect_equal(res$mvsusie$L1$config_summary$lbf_outcome, c(5, 7))
   expect_equal(res$mvsusie$L2$config_summary$lbf_outcome, c(3, 5))
-  expect_true(all(c("cs", "single_effect", "hit", "maxPIP") %in%
+  expect_true(all(c("cs", "n_variant", "purity", "hit", "maxPIP") %in%
                     colnames(res$mvsusie$L1$cs_summary)))
 })
 
@@ -378,13 +387,20 @@ test_that("method = 'mvsusie' covers CS member edge cases", {
   res <- susie_post_outcome_configuration(fit, method = "mvsusie")
   expect_equal(res$mvsusie$L1$cs_variant_summary$variant, c("s1", "s2"))
   expect_equal(res$mvsusie$L1$cs_variant_summary$pip, c(0.7, 0.2))
+  expect_true(is.na(res$mvsusie$L1$cs_summary$purity))
+
+  fit$sets$purity <- matrix(0.61, nrow = 1)
+  expect_equal(mvsusie_cs_purity(fit, label = "L1", idx = 1L), 0.61)
+  expect_true(is.na(mvsusie_cs_purity(fit, label = "missing", idx = 99L)))
 
   unnamed_cs <- fit
   unnamed_cs$sets$cs <- list(2L)
+  unnamed_cs$sets$purity <- data.frame(min.abs.corr = 0.42)
   attr(unnamed_cs$sets$cs, "cs_idx") <- 1L
   res_unnamed <- susie_post_outcome_configuration(unnamed_cs,
                                                   method = "mvsusie")
   expect_equal(res_unnamed$mvsusie$L1$cs_summary$hit, "s2")
+  expect_equal(res_unnamed$mvsusie$L1$cs_summary$purity, 0.42)
 
   no_pip <- fit
   no_pip$pip <- NULL
@@ -396,7 +412,7 @@ test_that("method = 'mvsusie' covers CS member edge cases", {
   bad_members$sets$cs <- list(L1 = 99L)
   res_bad_members <- susie_post_outcome_configuration(bad_members,
                                                       method = "mvsusie")
-  expect_equal(res_bad_members$mvsusie$L1$cs_summary$n_cs, 1L)
+  expect_equal(res_bad_members$mvsusie$L1$cs_summary$n_variant, 1L)
   expect_equal(nrow(res_bad_members$mvsusie$L1$cs_variant_summary), 0L)
 
   zero_alpha <- coloc_mv_fit(matrix(c(0, 0,

--- a/tests/testthat/test_post_outcome_configuration.R
+++ b/tests/testthat/test_post_outcome_configuration.R
@@ -171,6 +171,7 @@ test_that("method = 'susiex' returns tagged object with $susiex component", {
   expect_identical(attr(res, "method"), "susiex")
   expect_equal(attr(res, "prob_thresh"), 0.8)
   expect_true(length(res$susiex) >= 1L)
+  expect_true(all(grepl("^config_[0-9]+$", names(res$susiex))))
   # Each tuple carries the documented fields.
   expect_named(res$susiex[[1]], c("config_probability", "config_summary"))
   expect_named(attr(res$susiex[[1]], "raw"),
@@ -243,11 +244,12 @@ test_that("method = 'susiex' returns mvSuSiE CS summaries with SuSiEx activation
   expect_type(res$susiex, "list")
   expect_named(res$susiex, c("L3", "L1"))
   expect_named(res$susiex$L3, c("config_probability", "config_summary"))
-  expect_named(res$mvsusie,
+  expect_named(res$mvsusie, c("L3", "L1"))
+  expect_named(res$mvsusie$L3,
                c("cs_summary", "config_summary", "cs_variant_summary"))
 
-  l3_cs <- res$mvsusie$cs_summary[res$mvsusie$cs_summary$cs == "L3", ]
-  expect_s3_class(res$mvsusie$cs_summary, "data.frame")
+  l3_cs <- res$mvsusie$L3$cs_summary
+  expect_s3_class(l3_cs, "data.frame")
   expect_equal(l3_cs$cs, "L3")
   expect_equal(l3_cs$n_variant, 2L)
   expect_equal(l3_cs$purity, 0.77)
@@ -256,10 +258,10 @@ test_that("method = 'susiex' returns mvSuSiE CS summaries with SuSiEx activation
   expect_equal(l3_cs$lbf, 5)
   expect_equal(l3_cs$n_lfsr_outcome, 1L)
 
-  l3_config <- res$mvsusie$config_summary[res$mvsusie$config_summary$cs == "L3", ]
-  expect_s3_class(res$mvsusie$config_summary, "data.frame")
+  l3_config <- res$mvsusie$L3$config_summary
+  expect_s3_class(l3_config, "data.frame")
   expect_named(l3_config,
-               c("cs", "outcome", "lbf_outcome", "sentinel_variant",
+               c("outcome", "lbf_outcome", "sentinel_variant",
                  "sentinel_lfsr", "lfsr_pass", "lfsr_cutoff"))
   expect_equal(l3_config$outcome, c("old", "new"))
   expect_equal(l3_config$lbf_outcome, c(3, 0))
@@ -271,13 +273,12 @@ test_that("method = 'susiex' returns mvSuSiE CS summaries with SuSiEx activation
   expect_false("activation_summary" %in% names(res$susiex$L3))
   expect_false("posthoc_prob" %in% names(res$susiex$L3))
   expect_false("single_effect_lfsr" %in%
-                 colnames(res$mvsusie$config_summary))
+                 colnames(res$mvsusie$L3$config_summary))
 
-  l3_variants <- res$mvsusie$cs_variant_summary[
-    res$mvsusie$cs_variant_summary$cs == "L3", ]
-  expect_s3_class(res$mvsusie$cs_variant_summary, "data.frame")
+  l3_variants <- res$mvsusie$L3$cs_variant_summary
+  expect_s3_class(l3_variants, "data.frame")
   expect_named(l3_variants,
-               c("cs", "variant", "pip", "lfsr_old", "lfsr_new"))
+               c("variant", "pip", "lfsr_old", "lfsr_new"))
   expect_equal(l3_variants$variant, c("s3", "s4"))
   expect_equal(l3_variants$pip, c(0.2, 0.9))
   expect_equal(l3_variants$lfsr_old, c(0.2, 0.2))
@@ -297,9 +298,7 @@ test_that("method = 'susiex' returns mvSuSiE CS summaries with SuSiEx activation
 
   strict <- susie_post_outcome_configuration(
     fit, method = "susiex", single_effect_lfsr_cutoff = 0.01)
-  strict_l3 <- strict$mvsusie$config_summary[
-    strict$mvsusie$config_summary$cs == "L3", ]
-  expect_equal(strict_l3$lfsr_pass, c(FALSE, TRUE))
+  expect_equal(strict$mvsusie$L3$config_summary$lfsr_pass, c(FALSE, TRUE))
 })
 
 test_that("method = 'susiex' can compute lbf_outcome from alpha-weighted outcome LBFs", {
@@ -316,12 +315,10 @@ test_that("method = 'susiex' can compute lbf_outcome from alpha-weighted outcome
 
   res <- susie_post_outcome_configuration(fit, method = "susiex")
 
-  l1_config <- res$mvsusie$config_summary[res$mvsusie$config_summary$cs == "L1", ]
-  l2_config <- res$mvsusie$config_summary[res$mvsusie$config_summary$cs == "L2", ]
-  expect_equal(l1_config$lbf_outcome, c(5, 7))
-  expect_equal(l2_config$lbf_outcome, c(3, 5))
+  expect_equal(res$mvsusie$L1$config_summary$lbf_outcome, c(5, 7))
+  expect_equal(res$mvsusie$L2$config_summary$lbf_outcome, c(3, 5))
   expect_true(all(c("cs", "n_variant", "purity", "hit", "maxPIP") %in%
-                    colnames(res$mvsusie$cs_summary)))
+                    colnames(res$mvsusie$L1$cs_summary)))
 })
 
 test_that("method = 'susiex' handles mfsusie with the multi-output contract", {
@@ -361,8 +358,8 @@ test_that("method = 'susiex' covers input and missing-data edge cases", {
 
   res <- susie_post_outcome_configuration(
     list(fit), method = "susiex", outcome_names = c("old", "new"))
-  expect_equal(res$mvsusie$config_summary$outcome, c("old", "new"))
-  expect_equal(res$mvsusie$config_summary$sentinel_lfsr, c(0.01, 0.2))
+  expect_equal(res$mvsusie$L1$config_summary$outcome, c("old", "new"))
+  expect_equal(res$mvsusie$L1$config_summary$sentinel_lfsr, c(0.01, 0.2))
   expect_equal(rownames(res$susiex$L1$config_summary), c("old", "new"))
 
   expect_error(
@@ -432,9 +429,9 @@ test_that("method = 'susiex' covers CS member edge cases", {
   expect_true(is.na(missing_hit$hit))
 
   res <- susie_post_outcome_configuration(fit, method = "susiex")
-  expect_equal(res$mvsusie$cs_variant_summary$variant, c("s1", "s2"))
-  expect_equal(res$mvsusie$cs_variant_summary$pip, c(0.7, 0.2))
-  expect_true(is.na(res$mvsusie$cs_summary$purity))
+  expect_equal(res$mvsusie$L1$cs_variant_summary$variant, c("s1", "s2"))
+  expect_equal(res$mvsusie$L1$cs_variant_summary$pip, c(0.7, 0.2))
+  expect_true(is.na(res$mvsusie$L1$cs_summary$purity))
 
   fit$sets$purity <- matrix(0.61, nrow = 1)
   expect_equal(mvsusie_cs_purity(fit, label = "L1", idx = 1L), 0.61)
@@ -446,21 +443,21 @@ test_that("method = 'susiex' covers CS member edge cases", {
   attr(unnamed_cs$sets$cs, "cs_idx") <- 1L
   res_unnamed <- susie_post_outcome_configuration(unnamed_cs,
                                                   method = "susiex")
-  expect_equal(res_unnamed$mvsusie$cs_summary$hit, "s2")
-  expect_equal(res_unnamed$mvsusie$cs_summary$purity, 0.42)
+  expect_equal(res_unnamed$mvsusie$L1$cs_summary$hit, "s2")
+  expect_equal(res_unnamed$mvsusie$L1$cs_summary$purity, 0.42)
 
   no_pip <- fit
   no_pip$pip <- NULL
   res_no_pip <- susie_post_outcome_configuration(no_pip, method = "susiex")
-  expect_true(all(is.na(res_no_pip$mvsusie$cs_variant_summary$pip)))
-  expect_true(all(is.na(res_no_pip$mvsusie$cs_summary$hit)))
+  expect_true(all(is.na(res_no_pip$mvsusie$L1$cs_variant_summary$pip)))
+  expect_true(all(is.na(res_no_pip$mvsusie$L1$cs_summary$hit)))
 
   bad_members <- fit
   bad_members$sets$cs <- list(L1 = 99L)
   res_bad_members <- susie_post_outcome_configuration(bad_members,
                                                       method = "susiex")
-  expect_equal(res_bad_members$mvsusie$cs_summary$n_variant, 1L)
-  expect_equal(nrow(res_bad_members$mvsusie$cs_variant_summary), 0L)
+  expect_equal(res_bad_members$mvsusie$L1$cs_summary$n_variant, 1L)
+  expect_equal(nrow(res_bad_members$mvsusie$L1$cs_variant_summary), 0L)
 
   zero_alpha <- coloc_mv_fit(matrix(c(0, 0,
                                       0, 1), 2, 2, byrow = TRUE),
@@ -796,6 +793,7 @@ test_that("susiex_configurations computes variant-level config / marginal probs 
          sets_cs = list(L1 = 1L)))
   res <- susiex_configurations(v, by = "fit", prob_thresh = 0.8)
   expect_length(res, 1L)
+  expect_named(res, "config_1")
   tup <- res[[1]]
   raw <- attr(tup, "raw")
 
@@ -886,6 +884,18 @@ test_that("susiex_configurations aligns variant-level LBFs by column names", {
                tolerance = 1e-8)
   expect_equal(attr(rev, "raw")$marginal_prob,
                attr(same, "raw")$marginal_prob, tolerance = 1e-8)
+})
+
+test_that("susiex_configurations names ordinary CS tuples as configs", {
+  v <- list(
+    list(name = "g1", alpha = matrix(1, 2, 1), lbf = matrix(1, 2, 1),
+         sets_cs = list(L1 = 1L, L2 = 2L)),
+    list(name = "g2", alpha = matrix(1, 2, 1), lbf = matrix(1, 2, 1),
+         sets_cs = list(L1 = 1L, L2 = 2L)))
+
+  res <- susiex_configurations(v, by = "fit", prob_thresh = 0.8)
+
+  expect_named(res, paste0("config_", 1:4))
 })
 
 test_that("susiex_configurations rejects mismatched alpha / LBF names", {
@@ -1090,9 +1100,11 @@ test_that("by = 'outcome' on an mvsusie runs SuSiEx per-outcome on the diagonal"
   res <- susie_post_outcome_configuration(fit, method = "susiex",
                                           by = "outcome")
   # 3 outcome views => configs over 2^3 = 8 patterns; diagonal of 2 CSs => 2.
-  expect_named(res$mvsusie,
+  expect_named(res$mvsusie, c("L1", "L2"))
+  expect_named(res$mvsusie$L1,
                c("cs_summary", "config_summary", "cs_variant_summary"))
   expect_length(res$susiex, 2L)
+  expect_named(res$susiex, c("L1", "L2"))
   expect_named(res$susiex[[1]], c("config_probability", "config_summary"))
   expect_equal(nrow(res$susiex[[1]]$config_probability), 8L)
   expect_equal(rownames(res$susiex[[1]]$config_summary),

--- a/tests/testthat/test_post_outcome_configuration.R
+++ b/tests/testthat/test_post_outcome_configuration.R
@@ -36,6 +36,34 @@ test_that("entry point rejects malformed cs_only", {
                "cs_only")
 })
 
+test_that("entry point uses provided outcome_names for trait labels", {
+  fits <- list(coloc_fit(matrix(c(0, 1), 1, 2), matrix(c(0, 4), 1, 2)),
+               coloc_fit(matrix(c(1, 0), 1, 2), matrix(c(3, 0), 1, 2)))
+  res_sx <- susie_post_outcome_configuration(fits, method = "susiex",
+                                             outcome_names = c("MDD", "BP"))
+  expect_named(res_sx$susiex[[1]]$cs_indices, c("MDD", "BP"))
+
+  res_coloc <- susie_post_outcome_configuration(fits,
+                                                method = "coloc_pairwise",
+                                                outcome_names = c("MDD", "BP"))
+  expect_equal(res_coloc$coloc_pairwise$trait1, "MDD")
+  expect_equal(res_coloc$coloc_pairwise$trait2, "BP")
+})
+
+test_that("entry point rejects malformed outcome_names", {
+  fits <- list(coloc_fit(matrix(0.5, 1, 2), matrix(1, 1, 2)),
+               coloc_fit(matrix(0.5, 1, 2), matrix(1, 1, 2)))
+  expect_error(susie_post_outcome_configuration(fits,
+                                                outcome_names = "one"),
+               "outcome_names")
+  expect_error(susie_post_outcome_configuration(fits,
+                                                outcome_names = c("one", NA)),
+               "outcome_names")
+  expect_error(susie_post_outcome_configuration(fits,
+                                                outcome_names = c("one", "")),
+               "outcome_names")
+})
+
 test_that("entry point rejects malformed p1/p2/p12 priors", {
   fit <- coloc_fit(matrix(0.5, 1, 2), matrix(1, 1, 2))
   expect_error(

--- a/tests/testthat/test_post_outcome_configuration.R
+++ b/tests/testthat/test_post_outcome_configuration.R
@@ -345,20 +345,33 @@ test_that("susiex_configurations returns list() when no usable CS tuple exists",
                                      prob_thresh = 0.8), list())
 })
 
-test_that("susiex_configurations computes config / marginal probs correctly", {
-  # Two traits, each with a single CS at a single SNP. logBF_trait[n] =
-  # sum(alpha * lbf). With alpha = 1 at SNP1, logBF = lbf value there.
+test_that("susiex_configurations computes variant-level config / marginal probs correctly", {
+  # Two traits, each with one CS row over two aligned variants.
+  # logBF_trait and config_prob use the same variant-level LBF kernel.
   v <- list(
-    list(name = "g1", alpha = matrix(c(1, 0), 1, 2),
-         lbf = matrix(c(2, 0), 1, 2), sets_cs = list(L1 = 1L)),
-    list(name = "g2", alpha = matrix(c(1, 0), 1, 2),
-         lbf = matrix(c(3, 0), 1, 2), sets_cs = list(L1 = 1L)))
+    list(name = "g1",
+         alpha = matrix(c(1, 0), 1, 2,
+                        dimnames = list(NULL, c("rs1", "rs2"))),
+         lbf = matrix(c(2, 0), 1, 2,
+                      dimnames = list(NULL, c("rs1", "rs2"))),
+         sets_cs = list(L1 = 1L)),
+    list(name = "g2",
+         alpha = matrix(c(1, 0), 1, 2,
+                        dimnames = list(NULL, c("rs1", "rs2"))),
+         lbf = matrix(c(3, 0), 1, 2,
+                      dimnames = list(NULL, c("rs1", "rs2"))),
+         sets_cs = list(L1 = 1L)))
   res <- susiex_configurations(v, by = "fit", prob_thresh = 0.8)
   expect_length(res, 1L)
   tup <- res[[1]]
 
-  # logBF_trait = c(2, 3), named by trait.
-  expect_equal(tup$logBF_trait, c(g1 = 2, g2 = 3), tolerance = 1e-8)
+  lbf <- list(g1 = c(rs1 = 2, rs2 = 0), g2 = c(rs1 = 3, rs2 = 0))
+
+  # logBF_trait is the singleton-activation log BF, named by trait.
+  expect_equal(tup$logBF_trait,
+               c(g1 = log(sum(exp(-log(2) + lbf$g1))),
+                 g2 = log(sum(exp(-log(2) + lbf$g2)))),
+               tolerance = 1e-8)
   expect_named(tup$cs_indices, c("g1", "g2"))
 
   # config_prob is a proper distribution over 2^2 = 4 configs.
@@ -367,8 +380,13 @@ test_that("susiex_configurations computes config / marginal probs correctly", {
   expect_length(tup$marginal_prob, 2L)
   expect_named(tup$marginal_prob, c("g1", "g2"))
 
-  # Independent recomputation of the marginals from the configs matrix.
-  logBF_conf <- as.vector(tup$configs %*% c(2, 3))
+  # Independent recomputation from the variant-level SuSiEx kernel over
+  # aligned variants.
+  logBF_conf <- apply(tup$configs, 1, function(cfg) {
+    active <- which(cfg == 1L)
+    if (length(active) == 0L) return(0)
+    log(sum(exp(-log(2) + Reduce("+", lbf[active]))))
+  })
   p <- exp(logBF_conf - max(logBF_conf)); p <- p / sum(p)
   expect_equal(unname(tup$config_prob), p, tolerance = 1e-8)
   expect_equal(unname(tup$marginal_prob),
@@ -376,6 +394,73 @@ test_that("susiex_configurations computes config / marginal probs correctly", {
 
   # active = marginal >= prob_thresh.
   expect_equal(tup$active, tup$marginal_prob >= 0.8)
+})
+
+test_that("susiex_configurations does not call disjoint strong signals shared", {
+  variants <- c("rs1", "rs2", "rs3")
+  make_view <- function(name, peak) {
+    alpha <- matrix(0, 1, 3, dimnames = list(NULL, variants))
+    lbf   <- matrix(-20, 1, 3, dimnames = list(NULL, variants))
+    alpha[1, peak] <- 1
+    lbf[1, peak]   <- 12
+    list(name = name, alpha = alpha, lbf = lbf,
+         sets_cs = list(L1 = match(peak, variants)))
+  }
+  v <- list(make_view("t1", "rs1"),
+            make_view("t2", "rs2"),
+            make_view("t3", "rs3"))
+
+  tup <- susiex_configurations(v, by = "fit", prob_thresh = 0.8)[[1]]
+  all_active <- which(rowSums(tup$configs) == 3L)
+
+  expect_lt(tup$config_prob[all_active], 1e-8)
+  expect_true(all(tup$marginal_prob < 0.8))
+  expect_false(any(tup$active))
+})
+
+test_that("susiex_configurations aligns variant-level LBFs by column names", {
+  alpha1 <- matrix(c(1, 0), 1, 2, dimnames = list(NULL, c("rs1", "rs2")))
+  lbf1   <- matrix(c(8, 0), 1, 2, dimnames = list(NULL, c("rs1", "rs2")))
+
+  alpha2_same <- matrix(c(1, 0), 1, 2, dimnames = list(NULL, c("rs1", "rs2")))
+  lbf2_same   <- matrix(c(8, 0), 1, 2, dimnames = list(NULL, c("rs1", "rs2")))
+  alpha2_rev  <- matrix(c(0, 1), 1, 2, dimnames = list(NULL, c("rs2", "rs1")))
+  lbf2_rev    <- matrix(c(0, 8), 1, 2, dimnames = list(NULL, c("rs2", "rs1")))
+
+  v_same <- list(
+    list(name = "g1", alpha = alpha1, lbf = lbf1, sets_cs = list(L1 = 1L)),
+    list(name = "g2", alpha = alpha2_same, lbf = lbf2_same,
+         sets_cs = list(L1 = 1L)))
+  v_rev <- list(
+    list(name = "g1", alpha = alpha1, lbf = lbf1, sets_cs = list(L1 = 1L)),
+    list(name = "g2", alpha = alpha2_rev, lbf = lbf2_rev,
+         sets_cs = list(L1 = 1L)))
+
+  same <- susiex_configurations(v_same, by = "fit", prob_thresh = 0.8)[[1]]
+  rev  <- susiex_configurations(v_rev,  by = "fit", prob_thresh = 0.8)[[1]]
+
+  expect_equal(rev$config_prob, same$config_prob, tolerance = 1e-8)
+  expect_equal(rev$marginal_prob, same$marginal_prob, tolerance = 1e-8)
+})
+
+test_that("susiex_configurations rejects mismatched alpha / LBF names", {
+  v <- list(
+    list(name = "bad",
+         alpha = matrix(c(1, 0), 1, 2,
+                        dimnames = list(NULL, c("rs1", "rs2"))),
+         lbf = matrix(c(2, 0), 1, 2,
+                      dimnames = list(NULL, c("rs2", "rs1"))),
+         sets_cs = list(L1 = 1L)),
+    list(name = "ok",
+         alpha = matrix(c(1, 0), 1, 2,
+                        dimnames = list(NULL, c("rs1", "rs2"))),
+         lbf = matrix(c(3, 0), 1, 2,
+                      dimnames = list(NULL, c("rs1", "rs2"))),
+         sets_cs = list(L1 = 1L)))
+
+  expect_error(
+    susiex_configurations(v, by = "fit", prob_thresh = 0.8),
+    "column names of `alpha` and `lbf` must match")
 })
 
 test_that("susiex_configurations is reachable through the public entry point", {

--- a/tests/testthat/test_post_outcome_configuration.R
+++ b/tests/testthat/test_post_outcome_configuration.R
@@ -41,7 +41,7 @@ test_that("entry point uses provided outcome_names for trait labels", {
                coloc_fit(matrix(c(1, 0), 1, 2), matrix(c(3, 0), 1, 2)))
   res_sx <- susie_post_outcome_configuration(fits, method = "susiex",
                                              outcome_names = c("MDD", "BP"))
-  expect_named(res_sx$susiex[[1]]$activation_summary, c("MDD", "BP"))
+  expect_equal(rownames(res_sx$susiex[[1]]$config_summary), c("MDD", "BP"))
 
   res_coloc <- susie_post_outcome_configuration(fits,
                                                 method = "coloc_pairwise",
@@ -78,7 +78,7 @@ test_that("entry point skips traits with no credible sets", {
     "drop_me"
   )
   expect_s3_class(res, "susie_post_outcome_configuration")
-  expect_named(res$susiex[[1]]$activation_summary, c("A", "B"))
+  expect_equal(rownames(res$susiex[[1]]$config_summary), c("A", "B"))
 })
 
 test_that("entry point returns NULL when all traits have no credible sets", {
@@ -172,7 +172,7 @@ test_that("method = 'susiex' returns tagged object with $susiex component", {
   expect_equal(attr(res, "prob_thresh"), 0.8)
   expect_true(length(res$susiex) >= 1L)
   # Each tuple carries the documented fields.
-  expect_named(res$susiex[[1]], c("config_probability", "activation_summary"))
+  expect_named(res$susiex[[1]], c("config_probability", "config_summary"))
   expect_named(attr(res$susiex[[1]], "raw"),
                c("cs_indices", "cs_labels", "logBF_trait", "configs",
                  "config_prob", "marginal_prob", "active"))
@@ -238,66 +238,68 @@ test_that("method = 'susiex' returns mvSuSiE CS summaries with SuSiEx activation
 
   expect_s3_class(res, "susie_post_outcome_configuration")
   expect_true("susiex" %in% names(res))
-  expect_false("mvsusie" %in% names(res))
+  expect_true("mvsusie" %in% names(res))
   expect_identical(attr(res, "method"), "susiex")
   expect_type(res$susiex, "list")
   expect_named(res$susiex, c("L3", "L1"))
-  expect_named(res$susiex$L3,
-               c("mvsusie_cs_summary", "mvsusie_config_summary", "mvsusie_cs_variant_summary",
-                 "susiex_config_probability", "susiex_activation_summary"))
+  expect_named(res$susiex$L3, c("config_probability", "config_summary"))
+  expect_named(res$mvsusie,
+               c("cs_summary", "config_summary", "cs_variant_summary"))
 
-  expect_s3_class(res$susiex$L3$mvsusie_cs_summary, "data.frame")
-  expect_equal(res$susiex$L3$mvsusie_cs_summary$cs, "L3")
-  expect_equal(res$susiex$L3$mvsusie_cs_summary$n_variant, 2L)
-  expect_equal(res$susiex$L3$mvsusie_cs_summary$purity, 0.77)
-  expect_equal(res$susiex$L3$mvsusie_cs_summary$hit, "s4")
-  expect_equal(res$susiex$L3$mvsusie_cs_summary$maxPIP, 0.9)
-  expect_equal(res$susiex$L3$mvsusie_cs_summary$lbf, 5)
-  expect_equal(res$susiex$L3$mvsusie_cs_summary$n_lfsr_outcome, 1L)
+  l3_cs <- res$mvsusie$cs_summary[res$mvsusie$cs_summary$cs == "L3", ]
+  expect_s3_class(res$mvsusie$cs_summary, "data.frame")
+  expect_equal(l3_cs$cs, "L3")
+  expect_equal(l3_cs$n_variant, 2L)
+  expect_equal(l3_cs$purity, 0.77)
+  expect_equal(l3_cs$hit, "s4")
+  expect_equal(l3_cs$maxPIP, 0.9)
+  expect_equal(l3_cs$lbf, 5)
+  expect_equal(l3_cs$n_lfsr_outcome, 1L)
 
-  expect_s3_class(res$susiex$L3$mvsusie_config_summary, "data.frame")
-  expect_named(res$susiex$L3$mvsusie_config_summary,
-               c("outcome", "lbf_outcome", "sentinel_variant",
+  l3_config <- res$mvsusie$config_summary[res$mvsusie$config_summary$cs == "L3", ]
+  expect_s3_class(res$mvsusie$config_summary, "data.frame")
+  expect_named(l3_config,
+               c("cs", "outcome", "lbf_outcome", "sentinel_variant",
                  "sentinel_lfsr", "lfsr_pass", "lfsr_cutoff"))
-  expect_equal(res$susiex$L3$mvsusie_config_summary$outcome, c("old", "new"))
-  expect_equal(res$susiex$L3$mvsusie_config_summary$lbf_outcome, c(3, 0))
-  expect_equal(res$susiex$L3$mvsusie_config_summary$sentinel_variant, c("s4", "s4"))
-  expect_equal(res$susiex$L3$mvsusie_config_summary$sentinel_lfsr, c(0.2, 0.003))
-  expect_equal(res$susiex$L3$mvsusie_config_summary$lfsr_pass, c(FALSE, TRUE))
-  expect_equal(res$susiex$L3$mvsusie_config_summary$lfsr_cutoff, c(0.05, 0.05))
+  expect_equal(l3_config$outcome, c("old", "new"))
+  expect_equal(l3_config$lbf_outcome, c(3, 0))
+  expect_equal(l3_config$sentinel_variant, c("s4", "s4"))
+  expect_equal(l3_config$sentinel_lfsr, c(0.2, 0.003))
+  expect_equal(l3_config$lfsr_pass, c(FALSE, TRUE))
+  expect_equal(l3_config$lfsr_cutoff, c(0.05, 0.05))
   expect_identical(attr(res, "single_effect_lfsr_cutoff"), 0.05)
   expect_false("activation_summary" %in% names(res$susiex$L3))
-  expect_true("susiex_activation_summary" %in% names(res$susiex$L3))
   expect_false("posthoc_prob" %in% names(res$susiex$L3))
   expect_false("single_effect_lfsr" %in%
-                 colnames(res$susiex$L3$mvsusie_config_summary))
+                 colnames(res$mvsusie$config_summary))
 
-  expect_s3_class(res$susiex$L3$mvsusie_cs_variant_summary, "data.frame")
-  expect_named(res$susiex$L3$mvsusie_cs_variant_summary,
-               c("variant", "pip", "lfsr_old", "lfsr_new"))
-  expect_equal(res$susiex$L3$mvsusie_cs_variant_summary$variant, c("s3", "s4"))
-  expect_equal(res$susiex$L3$mvsusie_cs_variant_summary$pip, c(0.2, 0.9))
-  expect_equal(res$susiex$L3$mvsusie_cs_variant_summary$lfsr_old, c(0.2, 0.2))
-  expect_equal(res$susiex$L3$mvsusie_cs_variant_summary$lfsr_new, c(0.2, 0.003))
-  expect_s3_class(res$susiex$L3$susiex_config_probability, "data.frame")
-  expect_named(res$susiex$L3$susiex_config_probability,
+  l3_variants <- res$mvsusie$cs_variant_summary[
+    res$mvsusie$cs_variant_summary$cs == "L3", ]
+  expect_s3_class(res$mvsusie$cs_variant_summary, "data.frame")
+  expect_named(l3_variants,
+               c("cs", "variant", "pip", "lfsr_old", "lfsr_new"))
+  expect_equal(l3_variants$variant, c("s3", "s4"))
+  expect_equal(l3_variants$pip, c(0.2, 0.9))
+  expect_equal(l3_variants$lfsr_old, c(0.2, 0.2))
+  expect_equal(l3_variants$lfsr_new, c(0.2, 0.003))
+  expect_s3_class(res$susiex$L3$config_probability, "data.frame")
+  expect_named(res$susiex$L3$config_probability,
                c("old", "new", "config_prob"))
-  expect_equal(nrow(res$susiex$L3$susiex_config_probability), 4L)
-  expect_s3_class(res$susiex$L3$susiex_activation_summary, "data.frame")
-  expect_named(res$susiex$L3$susiex_activation_summary, c("old", "new"))
-  expect_equal(
-    rownames(res$susiex$L3$susiex_activation_summary),
-    c("cs_indices", "logBF_trait", "posthoc_prob", "active"))
-  expect_equal(
-    as.character(res$susiex$L3$susiex_activation_summary["cs_indices", ]),
-    c("L3", "L3"))
+  expect_equal(nrow(res$susiex$L3$config_probability), 4L)
+  expect_s3_class(res$susiex$L3$config_summary, "data.frame")
+  expect_named(res$susiex$L3$config_summary,
+               c("cs_indices", "logBF_trait", "posthoc_prob", "active"))
+  expect_equal(rownames(res$susiex$L3$config_summary), c("old", "new"))
+  expect_equal(res$susiex$L3$config_summary$cs_indices, c("L3", "L3"))
   expect_named(attr(res$susiex$L3, "raw"),
                c("cs_indices", "cs_labels", "logBF_trait", "configs",
                  "config_prob", "marginal_prob", "active"))
 
   strict <- susie_post_outcome_configuration(
     fit, method = "susiex", single_effect_lfsr_cutoff = 0.01)
-  expect_equal(strict$susiex$L3$mvsusie_config_summary$lfsr_pass, c(FALSE, TRUE))
+  strict_l3 <- strict$mvsusie$config_summary[
+    strict$mvsusie$config_summary$cs == "L3", ]
+  expect_equal(strict_l3$lfsr_pass, c(FALSE, TRUE))
 })
 
 test_that("method = 'susiex' can compute lbf_outcome from alpha-weighted outcome LBFs", {
@@ -314,10 +316,12 @@ test_that("method = 'susiex' can compute lbf_outcome from alpha-weighted outcome
 
   res <- susie_post_outcome_configuration(fit, method = "susiex")
 
-  expect_equal(res$susiex$L1$mvsusie_config_summary$lbf_outcome, c(5, 7))
-  expect_equal(res$susiex$L2$mvsusie_config_summary$lbf_outcome, c(3, 5))
+  l1_config <- res$mvsusie$config_summary[res$mvsusie$config_summary$cs == "L1", ]
+  l2_config <- res$mvsusie$config_summary[res$mvsusie$config_summary$cs == "L2", ]
+  expect_equal(l1_config$lbf_outcome, c(5, 7))
+  expect_equal(l2_config$lbf_outcome, c(3, 5))
   expect_true(all(c("cs", "n_variant", "purity", "hit", "maxPIP") %in%
-                    colnames(res$susiex$L1$mvsusie_cs_summary)))
+                    colnames(res$mvsusie$cs_summary)))
 })
 
 test_that("method = 'susiex' handles mfsusie with the multi-output contract", {
@@ -338,9 +342,10 @@ test_that("method = 'susiex' handles mfsusie with the multi-output contract", {
   res <- susie_post_outcome_configuration(fit, method = "susiex")
 
   expect_true("susiex" %in% names(res))
+  expect_true("mvsusie" %in% names(res))
   expect_named(res$susiex, "L1")
-  expect_named(res$susiex$L1$susiex_activation_summary, c("old", "new"))
-  expect_equal(nrow(res$susiex$L1$susiex_config_probability), 4L)
+  expect_equal(rownames(res$susiex$L1$config_summary), c("old", "new"))
+  expect_equal(nrow(res$susiex$L1$config_probability), 4L)
 })
 
 test_that("method = 'susiex' covers input and missing-data edge cases", {
@@ -356,9 +361,9 @@ test_that("method = 'susiex' covers input and missing-data edge cases", {
 
   res <- susie_post_outcome_configuration(
     list(fit), method = "susiex", outcome_names = c("old", "new"))
-  expect_equal(res$susiex$L1$mvsusie_config_summary$outcome, c("old", "new"))
-  expect_equal(res$susiex$L1$mvsusie_config_summary$sentinel_lfsr, c(0.01, 0.2))
-  expect_named(res$susiex$L1$susiex_activation_summary, c("old", "new"))
+  expect_equal(res$mvsusie$config_summary$outcome, c("old", "new"))
+  expect_equal(res$mvsusie$config_summary$sentinel_lfsr, c(0.01, 0.2))
+  expect_equal(rownames(res$susiex$L1$config_summary), c("old", "new"))
 
   expect_error(
     susie_post_outcome_configuration(fit, method = "mvsusie"),
@@ -427,9 +432,9 @@ test_that("method = 'susiex' covers CS member edge cases", {
   expect_true(is.na(missing_hit$hit))
 
   res <- susie_post_outcome_configuration(fit, method = "susiex")
-  expect_equal(res$susiex$L1$mvsusie_cs_variant_summary$variant, c("s1", "s2"))
-  expect_equal(res$susiex$L1$mvsusie_cs_variant_summary$pip, c(0.7, 0.2))
-  expect_true(is.na(res$susiex$L1$mvsusie_cs_summary$purity))
+  expect_equal(res$mvsusie$cs_variant_summary$variant, c("s1", "s2"))
+  expect_equal(res$mvsusie$cs_variant_summary$pip, c(0.7, 0.2))
+  expect_true(is.na(res$mvsusie$cs_summary$purity))
 
   fit$sets$purity <- matrix(0.61, nrow = 1)
   expect_equal(mvsusie_cs_purity(fit, label = "L1", idx = 1L), 0.61)
@@ -441,21 +446,21 @@ test_that("method = 'susiex' covers CS member edge cases", {
   attr(unnamed_cs$sets$cs, "cs_idx") <- 1L
   res_unnamed <- susie_post_outcome_configuration(unnamed_cs,
                                                   method = "susiex")
-  expect_equal(res_unnamed$susiex$L1$mvsusie_cs_summary$hit, "s2")
-  expect_equal(res_unnamed$susiex$L1$mvsusie_cs_summary$purity, 0.42)
+  expect_equal(res_unnamed$mvsusie$cs_summary$hit, "s2")
+  expect_equal(res_unnamed$mvsusie$cs_summary$purity, 0.42)
 
   no_pip <- fit
   no_pip$pip <- NULL
   res_no_pip <- susie_post_outcome_configuration(no_pip, method = "susiex")
-  expect_true(all(is.na(res_no_pip$susiex$L1$mvsusie_cs_variant_summary$pip)))
-  expect_true(all(is.na(res_no_pip$susiex$L1$mvsusie_cs_summary$hit)))
+  expect_true(all(is.na(res_no_pip$mvsusie$cs_variant_summary$pip)))
+  expect_true(all(is.na(res_no_pip$mvsusie$cs_summary$hit)))
 
   bad_members <- fit
   bad_members$sets$cs <- list(L1 = 99L)
   res_bad_members <- susie_post_outcome_configuration(bad_members,
                                                       method = "susiex")
-  expect_equal(res_bad_members$susiex$L1$mvsusie_cs_summary$n_variant, 1L)
-  expect_equal(nrow(res_bad_members$susiex$L1$mvsusie_cs_variant_summary), 0L)
+  expect_equal(res_bad_members$mvsusie$cs_summary$n_variant, 1L)
+  expect_equal(nrow(res_bad_members$mvsusie$cs_variant_summary), 0L)
 
   zero_alpha <- coloc_mv_fit(matrix(c(0, 0,
                                       0, 1), 2, 2, byrow = TRUE),
@@ -516,14 +521,13 @@ test_that("internal helpers cover defensive display branches", {
   names(tup_fallback$cs_indices) <- NULL
   tup_fallback$cs_labels <- setNames(c("L1", "L2"), c("a", "b"))
   org_fallback <- .organize_susiex_output(list(tup_fallback))[[1]]
-  expect_named(org_fallback$activation_summary, c("a", "b"))
+  expect_equal(rownames(org_fallback$config_summary), c("a", "b"))
 
   tup_no_labels <- coloc_tuple(c("a", "b"), cs_indices = c(1, 2),
                                marginal_prob = c(0.9, 0.8))
   tup_no_labels$cs_labels <- NULL
   org_no_labels <- .organize_susiex_output(list(tup_no_labels))[[1]]
-  expect_equal(as.character(org_no_labels$activation_summary["cs_indices", ]),
-               c("L1", "L2"))
+  expect_equal(org_no_labels$config_summary$cs_indices, c("L1", "L2"))
 
   wrapped <- list(shown = FALSE)
   attr(wrapped, "raw") <- list(shown = TRUE)
@@ -825,11 +829,10 @@ test_that("susiex_configurations computes variant-level config / marginal probs 
                c("g1", "g2", "config_prob"))
   expect_equal(tup$config_probability$config_prob, raw$config_prob,
                tolerance = 1e-8)
-  expect_equal(rownames(tup$activation_summary),
+  expect_named(tup$config_summary,
                c("cs_indices", "logBF_trait", "posthoc_prob", "active"))
-  expect_named(tup$activation_summary, c("g1", "g2"))
-  expect_equal(unname(unlist(tup$activation_summary["cs_indices", ])),
-               c("L1", "L1"))
+  expect_equal(rownames(tup$config_summary), c("g1", "g2"))
+  expect_equal(tup$config_summary$cs_indices, c("L1", "L1"))
 
   # active = marginal >= prob_thresh.
   expect_equal(raw$active, raw$marginal_prob >= 0.8)
@@ -1087,12 +1090,12 @@ test_that("by = 'outcome' on an mvsusie runs SuSiEx per-outcome on the diagonal"
   res <- susie_post_outcome_configuration(fit, method = "susiex",
                                           by = "outcome")
   # 3 outcome views => configs over 2^3 = 8 patterns; diagonal of 2 CSs => 2.
+  expect_named(res$mvsusie,
+               c("cs_summary", "config_summary", "cs_variant_summary"))
   expect_length(res$susiex, 2L)
-  expect_named(res$susiex[[1]],
-               c("mvsusie_cs_summary", "mvsusie_config_summary", "mvsusie_cs_variant_summary",
-                 "susiex_config_probability", "susiex_activation_summary"))
-  expect_equal(nrow(res$susiex[[1]]$susiex_config_probability), 8L)
-  expect_named(res$susiex[[1]]$susiex_activation_summary,
+  expect_named(res$susiex[[1]], c("config_probability", "config_summary"))
+  expect_equal(nrow(res$susiex[[1]]$config_probability), 8L)
+  expect_equal(rownames(res$susiex[[1]]$config_summary),
                c("o1", "o2", "o3"))
   expect_equal(unname(attr(res$susiex[[1]], "raw")$cs_indices),
                c(1L, 1L, 1L))

--- a/tests/testthat/test_post_outcome_configuration.R
+++ b/tests/testthat/test_post_outcome_configuration.R
@@ -96,7 +96,8 @@ test_that("method = 'susiex' returns tagged object with $susiex component", {
   expect_equal(attr(res, "prob_thresh"), 0.8)
   expect_true(length(res$susiex) >= 1L)
   # Each tuple carries the documented fields.
-  expect_named(res$susiex[[1]], c("cs_indices", "logBF_trait", "configs",
+  expect_named(res$susiex[[1]], c("config_probability", "activation_summary",
+                                  "cs_indices", "logBF_trait", "configs",
                                   "config_prob", "marginal_prob", "active"))
 })
 
@@ -419,6 +420,13 @@ test_that("susiex_configurations computes variant-level config / marginal probs 
   expect_equal(unname(tup$config_prob), p, tolerance = 1e-8)
   expect_equal(unname(tup$marginal_prob),
                as.vector(crossprod(tup$configs, p)), tolerance = 1e-8)
+  expect_named(tup$config_probability,
+               c("trait_1", "trait_2", "config_prob"))
+  expect_equal(tup$config_probability$config_prob, tup$config_prob,
+               tolerance = 1e-8)
+  expect_equal(rownames(tup$activation_summary),
+               c("cs_indices", "logBF_trait", "posthoc_prob", "active"))
+  expect_named(tup$activation_summary, c("g1", "g2"))
 
   # active = marginal >= prob_thresh.
   expect_equal(tup$active, tup$marginal_prob >= 0.8)

--- a/tests/testthat/test_post_outcome_configuration.R
+++ b/tests/testthat/test_post_outcome_configuration.R
@@ -64,6 +64,78 @@ test_that("entry point rejects malformed outcome_names", {
                "outcome_names")
 })
 
+test_that("entry point skips traits with no credible sets", {
+  no_cs <- structure(list(alpha = matrix(c(0, 1), 1, 2),
+                          lbf_variable = matrix(c(0, 4), 1, 2)),
+                     class = "susie")
+  has_a <- coloc_fit(matrix(c(1, 0), 1, 2), matrix(c(3, 0), 1, 2))
+  has_b <- coloc_fit(matrix(c(0, 1), 1, 2), matrix(c(0, 4), 1, 2))
+  expect_warning(
+    res <- susie_post_outcome_configuration(
+      list(no_cs, has_a, has_b),
+      method = "susiex",
+      outcome_names = c("drop_me", "A", "B")),
+    "drop_me"
+  )
+  expect_s3_class(res, "susie_post_outcome_configuration")
+  expect_named(res$susiex[[1]]$activation_summary, c("A", "B"))
+})
+
+test_that("entry point returns NULL when all traits have no credible sets", {
+  no_cs <- structure(list(alpha = matrix(c(0, 1), 1, 2),
+                          lbf_variable = matrix(c(0, 4), 1, 2)),
+                     class = "susie")
+  res <- "not null"
+  expect_message(
+    expect_warning(
+      res <- susie_post_outcome_configuration(
+        list(no_cs, no_cs),
+        method = "susiex",
+        outcome_names = c("a", "b")),
+      "a, b"
+    ),
+    "returning NULL"
+  )
+  expect_null(res)
+})
+
+test_that("entry point skips no-CS traits for coloc_pairwise", {
+  no_cs <- structure(list(alpha = matrix(c(0, 1), 1, 2),
+                          lbf_variable = matrix(c(0, 4), 1, 2)),
+                     class = "susie")
+  has_a <- coloc_fit(matrix(c(1, 0), 1, 2), matrix(c(3, 0), 1, 2))
+  has_b <- coloc_fit(matrix(c(0, 1), 1, 2), matrix(c(0, 4), 1, 2))
+  expect_warning(
+    res <- susie_post_outcome_configuration(
+      list(no_cs, has_a, has_b),
+      method = "coloc_pairwise",
+      outcome_names = c("drop_me", "A", "B")),
+    "drop_me"
+  )
+  expect_s3_class(res, "susie_post_outcome_configuration")
+  expect_equal(unique(res$coloc_pairwise$trait1), "A")
+  expect_equal(unique(res$coloc_pairwise$trait2), "B")
+})
+
+test_that("entry point returns NULL when coloc_pairwise has fewer than two CS traits", {
+  no_cs <- structure(list(alpha = matrix(c(0, 1), 1, 2),
+                          lbf_variable = matrix(c(0, 4), 1, 2)),
+                     class = "susie")
+  has_cs <- coloc_fit(matrix(c(1, 0), 1, 2), matrix(c(3, 0), 1, 2))
+  res <- "not null"
+  expect_message(
+    expect_warning(
+      res <- susie_post_outcome_configuration(
+        list(no_cs, has_cs),
+        method = "coloc_pairwise",
+        outcome_names = c("drop_me", "keep_me")),
+      "drop_me"
+    ),
+    "Fewer than two trait views"
+  )
+  expect_null(res)
+})
+
 test_that("entry point rejects malformed p1/p2/p12 priors", {
   fit <- coloc_fit(matrix(0.5, 1, 2), matrix(1, 1, 2))
   expect_error(
@@ -98,8 +170,8 @@ test_that("method = 'susiex' returns tagged object with $susiex component", {
   # Each tuple carries the documented fields.
   expect_named(res$susiex[[1]], c("config_probability", "activation_summary"))
   expect_named(attr(res$susiex[[1]], "raw"),
-               c("cs_indices", "logBF_trait", "configs", "config_prob",
-                 "marginal_prob", "active"))
+               c("cs_indices", "cs_labels", "logBF_trait", "configs",
+                 "config_prob", "marginal_prob", "active"))
 })
 
 test_that("method = 'coloc_pairwise' returns tagged object with coloc df", {
@@ -118,13 +190,14 @@ test_that("method = 'coloc_pairwise' returns tagged object with coloc df", {
   expect_equal(unname(rowSums(pp)), rep(1, nrow(pp)), tolerance = 1e-8)
 })
 
-test_that("entry point accepts a single fit (not wrapped in a list)", {
+test_that("entry point returns NULL for a single fit", {
   fit <- coloc_real_fit(7)
-  res <- susie_post_outcome_configuration(fit, method = "susiex", by = "fit")
-  expect_s3_class(res, "susie_post_outcome_configuration")
-  # Single trait => each config matrix has 2^1 = 2 rows.
-  expect_equal(nrow(res$susiex[[1]]$config_probability), 2L)
-  expect_equal(nrow(attr(res$susiex[[1]], "raw")$configs), 2L)
+  res <- "not null"
+  expect_message(
+    res <- susie_post_outcome_configuration(fit, method = "susiex", by = "fit"),
+    "Fewer than two trait views"
+  )
+  expect_null(res)
 })
 
 # ---- is_susie_fit() --------------------------------------------------------
@@ -142,32 +215,28 @@ test_that("is_susie_fit recognises susie / mvsusie / mfsusie only", {
 
 test_that("normalise_to_views wraps a single fit into a one-element view list", {
   fit   <- coloc_fit(matrix(0.5, 2, 3), matrix(1, 2, 3))
-  views <- normalise_to_views(fit, by = "fit", cs_only = TRUE)
+  views <- normalise_to_views(fit, by = "fit")
   expect_length(views, 1L)
   expect_equal(views[[1]]$name, "trait_1")
 })
 
 test_that("normalise_to_views errors on an empty list", {
-  expect_error(normalise_to_views(list(), by = "fit", cs_only = TRUE),
+  expect_error(normalise_to_views(list(), by = "fit"),
                "non-empty list")
 })
 
 test_that("normalise_to_views errors when an element is not a SuSiE fit", {
   fit <- coloc_fit(matrix(0.5, 1, 2), matrix(1, 1, 2))
   expect_error(
-    normalise_to_views(list(fit, 1), by = "fit", cs_only = TRUE),
+    normalise_to_views(list(fit, 1), by = "fit"),
     "Element 2 of `input` is not a SuSiE-class fit")
 })
 
-test_that("normalise_to_views requires $sets$cs only when cs_only = TRUE", {
+test_that("normalise_to_views does not require $sets$cs", {
   bare <- structure(list(alpha = matrix(0.5, 1, 2),
                          lbf_variable = matrix(1, 1, 2)),
                     class = "susie")
-  expect_error(
-    normalise_to_views(bare, by = "fit", cs_only = TRUE),
-    "requires `\\$sets\\$cs`")
-  # cs_only = FALSE does not need $sets$cs.
-  views <- normalise_to_views(bare, by = "fit", cs_only = FALSE)
+  views <- normalise_to_views(bare, by = "fit")
   expect_length(views, 1L)
 })
 
@@ -175,18 +244,15 @@ test_that("normalise_to_views keeps explicit names and defaults unnamed ones", {
   fitA <- coloc_fit(matrix(0.5, 1, 2), matrix(1, 1, 2))
   fitB <- coloc_fit(matrix(0.5, 1, 2), matrix(1, 1, 2))
   # Named list -> names preserved.
-  v_named <- normalise_to_views(list(gene = fitA, qtl = fitB),
-                                by = "fit", cs_only = TRUE)
+  v_named <- normalise_to_views(list(gene = fitA, qtl = fitB), by = "fit")
   expect_equal(vapply(v_named, function(v) v$name, character(1)),
                c("gene", "qtl"))
   # Unnamed list -> trait_1, trait_2.
-  v_unnamed <- normalise_to_views(list(fitA, fitB),
-                                  by = "fit", cs_only = TRUE)
+  v_unnamed <- normalise_to_views(list(fitA, fitB), by = "fit")
   expect_equal(vapply(v_unnamed, function(v) v$name, character(1)),
                c("trait_1", "trait_2"))
   # Partially named -> blank entries get the default.
-  v_partial <- normalise_to_views(list(gene = fitA, fitB),
-                                  by = "fit", cs_only = TRUE)
+  v_partial <- normalise_to_views(list(gene = fitA, fitB), by = "fit")
   expect_equal(vapply(v_partial, function(v) v$name, character(1)),
                c("gene", "trait_2"))
 })
@@ -289,14 +355,27 @@ test_that("view_cs_indices falls back to L-prefixed names", {
   expect_equal(view_cs_indices(v, cs_only = TRUE), c(1L, 3L))
 })
 
-test_that("view_cs_indices falls back to seq_len when sets_cs is empty or unnamed", {
-  # length-0 list
+test_that("view_cs_indices treats empty sets_cs as no CS", {
   v0 <- list(alpha = matrix(0, 3, 3), lbf = matrix(0, 3, 3), sets_cs = list())
-  expect_equal(view_cs_indices(v0, cs_only = TRUE), 1:3)
-  # named-less list
+  expect_equal(view_cs_indices(v0, cs_only = TRUE), integer(0))
+})
+
+test_that("view_cs_indices falls back to seq_len when sets_cs is unnamed", {
   vu <- list(alpha = matrix(0, 4, 3), lbf = matrix(0, 4, 3),
              sets_cs = list(1L, 1L))
   expect_equal(view_cs_indices(vu, cs_only = TRUE), 1:4)
+})
+
+test_that("view_cs_label uses original CS names", {
+  v <- list(alpha = matrix(0, 5, 3), lbf = matrix(0, 5, 3),
+            sets_cs = list(L2 = 1L, L4 = 1L))
+  expect_equal(view_cs_label(v, 2L), "L2")
+  expect_equal(view_cs_label(v, 4L), "L4")
+
+  sc <- structure(list(custom = 1L), cs_idx = 3L)
+  v_attr <- list(alpha = matrix(0, 5, 3), lbf = matrix(0, 5, 3),
+                 sets_cs = sc)
+  expect_equal(view_cs_label(v_attr, 3L), "custom")
 })
 
 test_that("view_cs_indices drops out-of-range CS indices", {
@@ -430,6 +509,8 @@ test_that("susiex_configurations computes variant-level config / marginal probs 
   expect_equal(rownames(tup$activation_summary),
                c("cs_indices", "logBF_trait", "posthoc_prob", "active"))
   expect_named(tup$activation_summary, c("g1", "g2"))
+  expect_equal(unname(unlist(tup$activation_summary["cs_indices", ])),
+               c("L1", "L1"))
 
   # active = marginal >= prob_thresh.
   expect_equal(raw$active, raw$marginal_prob >= 0.8)

--- a/tests/testthat/test_post_outcome_configuration.R
+++ b/tests/testthat/test_post_outcome_configuration.R
@@ -41,7 +41,7 @@ test_that("entry point uses provided outcome_names for trait labels", {
                coloc_fit(matrix(c(1, 0), 1, 2), matrix(c(3, 0), 1, 2)))
   res_sx <- susie_post_outcome_configuration(fits, method = "susiex",
                                              outcome_names = c("MDD", "BP"))
-  expect_named(res_sx$susiex[[1]]$cs_indices, c("MDD", "BP"))
+  expect_named(res_sx$susiex[[1]]$activation_summary, c("MDD", "BP"))
 
   res_coloc <- susie_post_outcome_configuration(fits,
                                                 method = "coloc_pairwise",
@@ -96,9 +96,10 @@ test_that("method = 'susiex' returns tagged object with $susiex component", {
   expect_equal(attr(res, "prob_thresh"), 0.8)
   expect_true(length(res$susiex) >= 1L)
   # Each tuple carries the documented fields.
-  expect_named(res$susiex[[1]], c("config_probability", "activation_summary",
-                                  "cs_indices", "logBF_trait", "configs",
-                                  "config_prob", "marginal_prob", "active"))
+  expect_named(res$susiex[[1]], c("config_probability", "activation_summary"))
+  expect_named(attr(res$susiex[[1]], "raw"),
+               c("cs_indices", "logBF_trait", "configs", "config_prob",
+                 "marginal_prob", "active"))
 })
 
 test_that("method = 'coloc_pairwise' returns tagged object with coloc df", {
@@ -122,7 +123,8 @@ test_that("entry point accepts a single fit (not wrapped in a list)", {
   res <- susie_post_outcome_configuration(fit, method = "susiex", by = "fit")
   expect_s3_class(res, "susie_post_outcome_configuration")
   # Single trait => each config matrix has 2^1 = 2 rows.
-  expect_equal(nrow(res$susiex[[1]]$configs), 2L)
+  expect_equal(nrow(res$susiex[[1]]$config_probability), 2L)
+  expect_equal(nrow(attr(res$susiex[[1]], "raw")$configs), 2L)
 })
 
 # ---- is_susie_fit() --------------------------------------------------------
@@ -393,43 +395,44 @@ test_that("susiex_configurations computes variant-level config / marginal probs 
   res <- susiex_configurations(v, by = "fit", prob_thresh = 0.8)
   expect_length(res, 1L)
   tup <- res[[1]]
+  raw <- attr(tup, "raw")
 
   lbf <- list(g1 = c(rs1 = 2, rs2 = 0), g2 = c(rs1 = 3, rs2 = 0))
 
   # logBF_trait is the singleton-activation log BF, named by trait.
-  expect_equal(tup$logBF_trait,
+  expect_equal(raw$logBF_trait,
                c(g1 = log(sum(exp(-log(2) + lbf$g1))),
                  g2 = log(sum(exp(-log(2) + lbf$g2)))),
                tolerance = 1e-8)
-  expect_named(tup$cs_indices, c("g1", "g2"))
+  expect_named(raw$cs_indices, c("g1", "g2"))
 
   # config_prob is a proper distribution over 2^2 = 4 configs.
-  expect_length(tup$config_prob, 4L)
-  expect_equal(sum(tup$config_prob), 1, tolerance = 1e-8)
-  expect_length(tup$marginal_prob, 2L)
-  expect_named(tup$marginal_prob, c("g1", "g2"))
+  expect_length(raw$config_prob, 4L)
+  expect_equal(sum(raw$config_prob), 1, tolerance = 1e-8)
+  expect_length(raw$marginal_prob, 2L)
+  expect_named(raw$marginal_prob, c("g1", "g2"))
 
   # Independent recomputation from the variant-level SuSiEx kernel over
   # aligned variants.
-  logBF_conf <- apply(tup$configs, 1, function(cfg) {
+  logBF_conf <- apply(raw$configs, 1, function(cfg) {
     active <- which(cfg == 1L)
     if (length(active) == 0L) return(0)
     log(sum(exp(-log(2) + Reduce("+", lbf[active]))))
   })
   p <- exp(logBF_conf - max(logBF_conf)); p <- p / sum(p)
-  expect_equal(unname(tup$config_prob), p, tolerance = 1e-8)
-  expect_equal(unname(tup$marginal_prob),
-               as.vector(crossprod(tup$configs, p)), tolerance = 1e-8)
+  expect_equal(unname(raw$config_prob), p, tolerance = 1e-8)
+  expect_equal(unname(raw$marginal_prob),
+               as.vector(crossprod(raw$configs, p)), tolerance = 1e-8)
   expect_named(tup$config_probability,
-               c("trait_1", "trait_2", "config_prob"))
-  expect_equal(tup$config_probability$config_prob, tup$config_prob,
+               c("g1", "g2", "config_prob"))
+  expect_equal(tup$config_probability$config_prob, raw$config_prob,
                tolerance = 1e-8)
   expect_equal(rownames(tup$activation_summary),
                c("cs_indices", "logBF_trait", "posthoc_prob", "active"))
   expect_named(tup$activation_summary, c("g1", "g2"))
 
   # active = marginal >= prob_thresh.
-  expect_equal(tup$active, tup$marginal_prob >= 0.8)
+  expect_equal(raw$active, raw$marginal_prob >= 0.8)
 })
 
 test_that("susiex_configurations does not call disjoint strong signals shared", {
@@ -447,11 +450,12 @@ test_that("susiex_configurations does not call disjoint strong signals shared", 
             make_view("t3", "rs3"))
 
   tup <- susiex_configurations(v, by = "fit", prob_thresh = 0.8)[[1]]
-  all_active <- which(rowSums(tup$configs) == 3L)
+  raw <- attr(tup, "raw")
+  all_active <- which(rowSums(raw$configs) == 3L)
 
-  expect_lt(tup$config_prob[all_active], 1e-8)
-  expect_true(all(tup$marginal_prob < 0.8))
-  expect_false(any(tup$active))
+  expect_lt(raw$config_prob[all_active], 1e-8)
+  expect_true(all(raw$marginal_prob < 0.8))
+  expect_false(any(raw$active))
 })
 
 test_that("susiex_configurations aligns variant-level LBFs by column names", {
@@ -475,8 +479,10 @@ test_that("susiex_configurations aligns variant-level LBFs by column names", {
   same <- susiex_configurations(v_same, by = "fit", prob_thresh = 0.8)[[1]]
   rev  <- susiex_configurations(v_rev,  by = "fit", prob_thresh = 0.8)[[1]]
 
-  expect_equal(rev$config_prob, same$config_prob, tolerance = 1e-8)
-  expect_equal(rev$marginal_prob, same$marginal_prob, tolerance = 1e-8)
+  expect_equal(attr(rev, "raw")$config_prob, attr(same, "raw")$config_prob,
+               tolerance = 1e-8)
+  expect_equal(attr(rev, "raw")$marginal_prob,
+               attr(same, "raw")$marginal_prob, tolerance = 1e-8)
 })
 
 test_that("susiex_configurations rejects mismatched alpha / LBF names", {
@@ -503,7 +509,8 @@ test_that("susiex_configurations is reachable through the public entry point", {
   fits <- list(coloc_real_fit(11), coloc_real_fit(12))
   res  <- susie_post_outcome_configuration(fits, method = "susiex", by = "fit")
   expect_true(length(res$susiex) >= 1L)
-  expect_equal(sum(res$susiex[[1]]$config_prob), 1, tolerance = 1e-8)
+  expect_equal(sum(attr(res$susiex[[1]], "raw")$config_prob), 1,
+               tolerance = 1e-8)
 })
 
 # ---- .logsum() / .logdiff() / combine_abf_pair() ---------------------------
@@ -681,9 +688,11 @@ test_that("by = 'outcome' on an mvsusie runs SuSiEx per-outcome on the diagonal"
                                           by = "outcome")
   # 3 outcome views => configs over 2^3 = 8 patterns; diagonal of 2 CSs => 2.
   expect_length(res$susiex, 2L)
-  expect_equal(nrow(res$susiex[[1]]$configs), 8L)
-  expect_equal(unname(res$susiex[[1]]$cs_indices), c(1L, 1L, 1L))
-  expect_equal(unname(res$susiex[[2]]$cs_indices), c(2L, 2L, 2L))
+  expect_equal(nrow(res$susiex[[1]]$config_probability), 8L)
+  expect_equal(unname(attr(res$susiex[[1]], "raw")$cs_indices),
+               c(1L, 1L, 1L))
+  expect_equal(unname(attr(res$susiex[[2]], "raw")$cs_indices),
+               c(2L, 2L, 2L))
 })
 
 # ---- Renderer color / NA branches ------------------------------------------

--- a/tests/testthat/test_post_outcome_configuration.R
+++ b/tests/testthat/test_post_outcome_configuration.R
@@ -551,6 +551,40 @@ test_that("coloc_pairwise_abf uses lbf colnames for hit labels when present", {
   expect_equal(df$hit2, "rsZ")
 })
 
+test_that("coloc_pairwise_abf aligns variant sets by name before ABF", {
+  cn_a <- c("rs1", "rs2", "rs3", "rs4")
+  cn_b <- c("rs3", "rs2", "rs5")
+  v <- list(
+    list(name = "A", alpha = matrix(c(0, 1, 0, 0), 1, 4,
+                                    dimnames = list(NULL, cn_a)),
+         lbf = matrix(c(0, 5, 0, 1), 1, 4, dimnames = list(NULL, cn_a)),
+         sets_cs = list(L1 = 1L)),
+    list(name = "B", alpha = matrix(c(0, 1, 0), 1, 3,
+                                    dimnames = list(NULL, cn_b)),
+         lbf = matrix(c(0, 5, 0), 1, 3, dimnames = list(NULL, cn_b)),
+         sets_cs = list(L1 = 1L)))
+  df <- coloc_pairwise_abf(v, p1 = 1e-4, p2 = 1e-4, p12 = 5e-6)
+  expected <- combine_abf_pair(c(5, 0), c(5, 0),
+                               p1 = 1e-4, p2 = 1e-4, p12 = 5e-6)
+  expect_equal(nrow(df), 1L)
+  expect_equal(df$hit1, "rs2")
+  expect_equal(df$hit2, "rs2")
+  expect_equal(unname(as.numeric(df[1, paste0("PP.H", 0:4)])),
+               unname(expected))
+})
+
+test_that("coloc_pairwise_abf errors on unequal unnamed variant sets", {
+  v <- list(
+    list(name = "A", alpha = matrix(c(0, 1, 0), 1, 3),
+         lbf = matrix(c(0, 5, 0), 1, 3),
+         sets_cs = list(L1 = 1L)),
+    list(name = "B", alpha = matrix(c(0, 1), 1, 2),
+         lbf = matrix(c(0, 5), 1, 2),
+         sets_cs = list(L1 = 1L)))
+  expect_error(coloc_pairwise_abf(v, p1 = 1e-4, p2 = 1e-4, p12 = 5e-6),
+               "cannot align unnamed variant sets")
+})
+
 test_that("coloc_pairwise_abf skips all-zero alpha rows in either trait", {
   # Both traits' only CS row is all-zero alpha => no eligible pairs.
   v_both <- list(

--- a/tests/testthat/test_post_outcome_configuration.R
+++ b/tests/testthat/test_post_outcome_configuration.R
@@ -190,6 +190,66 @@ test_that("method = 'coloc_pairwise' returns tagged object with coloc df", {
   expect_equal(unname(rowSums(pp)), rep(1, nrow(pp)), tolerance = 1e-8)
 })
 
+test_that("method = 'mvsusie' returns a CS-level mvSuSiE summary table", {
+  A <- matrix(0, 3, 4)
+  A[1, 1] <- 1; A[2, 2] <- 1; A[3, 3] <- 1
+  LV <- matrix(0, 3, 4)
+  lbf_out <- matrix(c(4, -1,
+                      1,  2,
+                      3,  0), nrow = 3, byrow = TRUE)
+  colnames(lbf_out) <- c("old", "new")
+  lfsr <- matrix(c(0.01, 1,
+                   0.2,  0.03,
+                   0.04, 0.5), nrow = 3, byrow = TRUE,
+                 dimnames = list(paste0("L", 1:3), c("old", "new")))
+  fit <- coloc_mv_fit(A, LV, array(0, dim = c(3, 4, 2)),
+                      cs = list(L3 = c(3L, 4L), L1 = 1L),
+                      lbf_outcome = lbf_out,
+                      single_effect_lfsr = lfsr)
+  fit$pip <- c(0.8, 0.1, 0.2, 0.9)
+  fit$lbf <- c(10, 2, 5)
+  fit$variable_names <- paste0("s", 1:4)
+
+  res <- susie_post_outcome_configuration(fit, method = "mvsusie")
+
+  expect_s3_class(res, "susie_post_outcome_configuration")
+  expect_true("mvsusie" %in% names(res))
+  expect_identical(attr(res, "method"), "mvsusie")
+  expect_s3_class(res$mvsusie, "data.frame")
+  expect_equal(res$mvsusie$cs, c("L3", "L1"))
+  expect_equal(res$mvsusie$single_effect, c(3L, 1L))
+  expect_equal(res$mvsusie$n_cs, c(2L, 1L))
+  expect_equal(res$mvsusie$hit, c("s4", "s1"))
+  expect_equal(res$mvsusie$maxPIP, c(0.9, 0.8))
+  expect_equal(res$mvsusie$lbf, c(5, 10))
+  expect_equal(res$mvsusie[["lbf_outcome.old"]], c(3, 4))
+  expect_equal(res$mvsusie[["lbf_outcome.new"]], c(0, -1))
+  expect_equal(res$mvsusie[["single_effect_lfsr.old"]], c(0.04, 0.01))
+  expect_equal(res$mvsusie[["single_effect_lfsr.new"]], c(0.5, 1))
+  expect_false("activation_summary" %in% names(res$mvsusie))
+  expect_false("posthoc_prob" %in% names(res$mvsusie))
+})
+
+test_that("method = 'mvsusie' can compute lbf_outcome from alpha-weighted outcome LBFs", {
+  A <- matrix(c(0.25, 0.75,
+                1.00, 0.00), nrow = 2, byrow = TRUE)
+  LV <- matrix(0, 2, 2)
+  arr <- array(0, dim = c(2, 2, 2),
+               dimnames = list(NULL, NULL, c("t1", "t2")))
+  arr[1, , 1] <- c(2, 6)
+  arr[1, , 2] <- c(4, 8)
+  arr[2, , 1] <- c(3, 9)
+  arr[2, , 2] <- c(5, 7)
+  fit <- coloc_mv_fit(A, LV, arr, cs = list(L1 = 1L, L2 = 2L))
+
+  res <- susie_post_outcome_configuration(fit, method = "mvsusie")
+
+  expect_equal(res$mvsusie[["lbf_outcome.t1"]], c(5, 3))
+  expect_equal(res$mvsusie[["lbf_outcome.t2"]], c(7, 5))
+  expect_true(all(c("cs", "single_effect", "hit", "maxPIP") %in%
+                    colnames(res$mvsusie)))
+})
+
 test_that("entry point returns NULL for a single fit", {
   fit <- coloc_real_fit(7)
   res <- "not null"

--- a/tests/testthat/test_post_outcome_configuration.R
+++ b/tests/testthat/test_post_outcome_configuration.R
@@ -262,12 +262,12 @@ test_that("method = 'susiex' returns mvSuSiE CS summaries with SuSiEx activation
   expect_s3_class(l3_config, "data.frame")
   expect_named(l3_config,
                c("outcome", "lbf_outcome", "sentinel_variant",
-                 "sentinel_lfsr", "lfsr_pass", "lfsr_cutoff"))
+                 "sentinel_lfsr", "lfsr_significant", "lfsr_cutoff"))
   expect_equal(l3_config$outcome, c("old", "new"))
   expect_equal(l3_config$lbf_outcome, c(3, 0))
   expect_equal(l3_config$sentinel_variant, c("s4", "s4"))
   expect_equal(l3_config$sentinel_lfsr, c(0.2, 0.003))
-  expect_equal(l3_config$lfsr_pass, c(FALSE, TRUE))
+  expect_equal(l3_config$lfsr_significant, c(FALSE, TRUE))
   expect_equal(l3_config$lfsr_cutoff, c(0.05, 0.05))
   expect_identical(attr(res, "single_effect_lfsr_cutoff"), 0.05)
   expect_false("activation_summary" %in% names(res$susiex$L3))
@@ -289,7 +289,7 @@ test_that("method = 'susiex' returns mvSuSiE CS summaries with SuSiEx activation
   expect_equal(nrow(res$susiex$L3$config_probability), 4L)
   expect_s3_class(res$susiex$L3$config_summary, "data.frame")
   expect_named(res$susiex$L3$config_summary,
-               c("cs_indices", "logBF_trait", "posthoc_prob", "active"))
+               c("cs_indices", "logBF_outcome", "posthoc_prob", "active"))
   expect_equal(rownames(res$susiex$L3$config_summary), c("old", "new"))
   expect_equal(res$susiex$L3$config_summary$cs_indices, c("L3", "L3"))
   expect_named(attr(res$susiex$L3, "raw"),
@@ -298,7 +298,7 @@ test_that("method = 'susiex' returns mvSuSiE CS summaries with SuSiEx activation
 
   strict <- susie_post_outcome_configuration(
     fit, method = "susiex", single_effect_lfsr_cutoff = 0.01)
-  expect_equal(strict$mvsusie$L3$config_summary$lfsr_pass, c(FALSE, TRUE))
+  expect_equal(strict$mvsusie$L3$config_summary$lfsr_significant, c(FALSE, TRUE))
 })
 
 test_that("method = 'susiex' can compute lbf_outcome from alpha-weighted outcome LBFs", {
@@ -828,7 +828,7 @@ test_that("susiex_configurations computes variant-level config / marginal probs 
   expect_equal(tup$config_probability$config_prob, raw$config_prob,
                tolerance = 1e-8)
   expect_named(tup$config_summary,
-               c("cs_indices", "logBF_trait", "posthoc_prob", "active"))
+               c("cs_indices", "logBF_outcome", "posthoc_prob", "active"))
   expect_equal(rownames(tup$config_summary), c("g1", "g2"))
   expect_equal(tup$config_summary$cs_indices, c("L1", "L1"))
 

--- a/tests/testthat/test_post_outcome_configuration_summary.R
+++ b/tests/testthat/test_post_outcome_configuration_summary.R
@@ -55,21 +55,12 @@ test_that("single-trait susiex tuple yields a one-trait tidy row", {
   expect_equal(s$susiex$solo, 0.95)
 })
 
-test_that("summary reads SuSiEx raw fields from enriched mvSuSiE CS entries", {
+test_that("summary reads SuSiEx raw fields from organized CS entries", {
   raw <- coloc_tuple(c("old", "new"), cs_indices = c(1, 1),
                      marginal_prob = c(0.91, 0.93))
-  enriched <- list(
-    mvsusie_cs_summary = data.frame(cs = "L1"),
-    mvsusie_config_summary = data.frame(outcome = c("old", "new")),
-    mvsusie_cs_variant_summary = data.frame(variant = "s1"),
-    susiex_config_probability = data.frame(old = c(0, 1),
-                                           new = c(0, 1),
-                                           config_prob = c(0.1, 0.9)),
-    susiex_activation_summary = data.frame(old = "TRUE", new = "TRUE")
-  )
-  attr(enriched, "raw") <- raw
+  organized <- .organize_susiex_output(list(raw))[[1]]
 
-  s <- summary(coloc_post_obj(susiex = list(L1 = enriched)),
+  s <- summary(coloc_post_obj(susiex = list(L1 = organized)),
                color = FALSE, signal_only = FALSE)
 
   expect_equal(nrow(s$susiex), 1L)

--- a/tests/testthat/test_post_outcome_configuration_summary.R
+++ b/tests/testthat/test_post_outcome_configuration_summary.R
@@ -55,6 +55,29 @@ test_that("single-trait susiex tuple yields a one-trait tidy row", {
   expect_equal(s$susiex$solo, 0.95)
 })
 
+test_that("summary reads SuSiEx raw fields from enriched mvSuSiE CS entries", {
+  raw <- coloc_tuple(c("old", "new"), cs_indices = c(1, 1),
+                     marginal_prob = c(0.91, 0.93))
+  enriched <- list(
+    mvsusie_cs_summary = data.frame(cs = "L1"),
+    mvsusie_config_summary = data.frame(outcome = c("old", "new")),
+    mvsusie_cs_variant_summary = data.frame(variant = "s1"),
+    susiex_config_probability = data.frame(old = c(0, 1),
+                                           new = c(0, 1),
+                                           config_prob = c(0.1, 0.9)),
+    susiex_activation_summary = data.frame(old = "TRUE", new = "TRUE")
+  )
+  attr(enriched, "raw") <- raw
+
+  s <- summary(coloc_post_obj(susiex = list(L1 = enriched)),
+               color = FALSE, signal_only = FALSE)
+
+  expect_equal(nrow(s$susiex), 1L)
+  expect_equal(s$susiex$tuple, "(1,1)")
+  expect_equal(s$susiex$old, 0.91)
+  expect_equal(s$susiex$new, 0.93)
+})
+
 test_that("coloc tidy table extends the input data.frame with verdict and top_pp", {
   rows <- list(
     list(t1 = "A", t2 = "B", l1 = 1, l2 = 1, h1 = "rs1", h2 = "rs1",


### PR DESCRIPTION
## Summary

This PR improves post-hoc multi-trait interpretation in `susieR` by making the sharing evidence more faithful to aligned variant-level signals, clarifying the distinction between SuSiEx-style activation and coloc-style colocalization, and adding mvSuSiE-oriented CS summaries.

## Major changes

### 1. Correct SuSiEx post-hoc scoring and clarify the conceptual framework

- Updates SuSiEx-style post-hoc configuration scoring to use aligned variant-level log-BF evidence instead of alpha-weighted CS-level averages.

- Clarifies that SuSiEx-style output is an activation-configuration summary, while coloc-style output explicitly distinguishes shared-causal from distinct-causal explanations.

### 2. Add mvSuSiE post-hoc summaries

- Adds an mvSuSiE summary mode that reports CS-level, outcome-level, and CS-variant-level evidence in a compact structure.

- Includes sentinel variant, purity, log-BF, PIP, and outcome-specific LFSR summaries for easier interpretation of multi-output mvSuSiE fits.

### 3. Improve robustness and validation

- Improves variant alignment across fits before post-hoc comparison.

- Adds coloc-style pairwise summaries to help distinguish shared signals from distinct signals.

- Expands tests for variant alignment, singleton configurations, disjoint signals, missing CS cases, and output structure.