### PR TITLE
avoid BLAS DGER integer overflow crash for large p.

### DIFF
--- a/R/sufficient_stats_methods.R
+++ b/R/sufficient_stats_methods.R
@@ -546,10 +546,7 @@ get_cs.ss <- function(data, params, model, ...) {
   }
 
   if (any(!(diag(data$XtX) %in% c(0, 1)))) {
-    d <- sqrt(diag(data$XtX))
-    d_inv <- 1 / d
-    d_inv[d == 0] <- 0
-    Xcorr <- structure(list(XtX = data$XtX, d_inv = d_inv), class = "scaled_XtX")
+    Xcorr <- structure(list(XtX = data$XtX), class = "scaled_XtX")
   } else {
     Xcorr <- data$XtX
   }
@@ -564,19 +561,12 @@ get_cs.ss <- function(data, params, model, ...) {
 }
 
 # Lazy submatrix extraction for scaled_XtX objects.
-# Computes Xcorr[i, j] = d_inv[i] * XtX[i, j] * d_inv[j] only for the
-# requested indices, so get_purity never needs a full n x n outer product.
-# Row/column scaling is done without outer() to avoid BLAS DGER integer
-# overflow for large submatrices.
+# Computes the correlation submatrix for the requested indices by delegating
+# to safe_cov2cor (which is now BLAS-free). This avoids materializing the
+# full n x n correlation matrix in get_cs.ss.
 #' @keywords internal
 `[.scaled_XtX` <- function(x, i, j, drop = TRUE) {
-  sub <- x$XtX[i, j, drop = FALSE]
-  di  <- x$d_inv[i]
-  dj  <- x$d_inv[j]
-  # Scale rows then columns: sub[r,c] = XtX[r,c] * d_inv[r] * d_inv[c]
-  sub <- sub * di
-  sub <- t(sub) * dj
-  diag(sub) <- 1
+  sub <- safe_cov2cor(x$XtX[i, j, drop = FALSE])
   if (drop && (nrow(sub) == 1L || ncol(sub) == 1L))
     sub <- drop(sub)
   sub

--- a/R/sufficient_stats_methods.R
+++ b/R/sufficient_stats_methods.R
@@ -530,7 +530,8 @@ get_fitted.ss <- function(data, params, model, ...) {
 # Get Credible Sets
 #' @keywords internal
 get_cs.ss <- function(data, params, model, ...) {
-  if (is.null(params$coverage) || is.null(params$min_abs_corr)) {
+  if (is.null(params$coverage) ||
+      (is.null(params$min_abs_corr) && is.null(params$median_abs_corr))) {
     return(NULL)
   }
 
@@ -545,7 +546,10 @@ get_cs.ss <- function(data, params, model, ...) {
   }
 
   if (any(!(diag(data$XtX) %in% c(0, 1)))) {
-    Xcorr <- safe_cov2cor(data$XtX)
+    d <- sqrt(diag(data$XtX))
+    d_inv <- 1 / d
+    d_inv[d == 0] <- 0
+    Xcorr <- structure(list(XtX = data$XtX, d_inv = d_inv), class = "scaled_XtX")
   } else {
     Xcorr <- data$XtX
   }
@@ -557,6 +561,25 @@ get_cs.ss <- function(data, params, model, ...) {
                       min_abs_corr    = params$min_abs_corr, median_abs_corr = params$median_abs_corr,
                       n_purity        = params$n_purity,
                       cs_extension_corr = params$cs_extension_corr))
+}
+
+# Lazy submatrix extraction for scaled_XtX objects.
+# Computes Xcorr[i, j] = d_inv[i] * XtX[i, j] * d_inv[j] only for the
+# requested indices, so get_purity never needs a full n x n outer product.
+# Row/column scaling is done without outer() to avoid BLAS DGER integer
+# overflow for large submatrices.
+#' @keywords internal
+`[.scaled_XtX` <- function(x, i, j, drop = TRUE) {
+  sub <- x$XtX[i, j, drop = FALSE]
+  di  <- x$d_inv[i]
+  dj  <- x$d_inv[j]
+  # Scale rows then columns: sub[r,c] = XtX[r,c] * d_inv[r] * d_inv[c]
+  sub <- sub * di
+  sub <- t(sub) * dj
+  diag(sub) <- 1
+  if (drop && (nrow(sub) == 1L || ncol(sub) == 1L))
+    sub <- drop(sub)
+  sub
 }
 
 # Get Variable Names

--- a/R/susie_utils.R
+++ b/R/susie_utils.R
@@ -2606,6 +2606,10 @@ get_purity <- function(pos, X, Xcorr, squared = FALSE, n = "auto",
       X_sub <- as.matrix(X_sub)
       value <- abs(get_upper_tri(safe_cor(X_sub)))
     } else {
+      n <- resolve_n_purity(n, length(pos), length(pos), use_rfast)
+      if (length(pos) > n) {
+        pos <- sample(pos, n)
+      }
       value <- abs(get_upper_tri(Xcorr[pos, pos]))
     }
     if (squared) {

--- a/R/susie_utils.R
+++ b/R/susie_utils.R
@@ -118,7 +118,10 @@ safe_cov2cor <- function(V) {
   d <- sqrt(diag(V))
   d_inv <- 1 / d
   d_inv[d == 0] <- 0
-  R <- V * outer(d_inv, d_inv)
+  # Avoid outer(d_inv, d_inv) which calls BLAS DGER: 32-bit integer overflow
+  # for large matrices (n > ~46K). Use BLAS-free row/column scaling instead.
+  R <- V * d_inv
+  R <- t(R) * d_inv
   diag(R) <- 1
   R
 }

--- a/tests/testthat/test_susie_utils.R
+++ b/tests/testthat/test_susie_utils.R
@@ -1556,23 +1556,30 @@ test_that("get_purity computes valid purity statistics", {
   expect_true(all(result_sq >= 0 & result_sq <= 1))
 })
 
-test_that("get_purity uses full Xcorr and subsamples only X path", {
+test_that("get_purity subsamples both X and Xcorr paths when n < length(pos)", {
   base_data <- generate_base_data(n = 80, p = 150, seed = 321)
   pos <- 1:120
   Xcorr <- cor(base_data$X)
-  upper <- abs(Xcorr[pos, pos][upper.tri(Xcorr[pos, pos])])
-  expected <- c(min(upper), sum(upper) / length(upper), median(upper))
 
+  # Xcorr path: with n=20 < 120, subsampling applies → different seeds → different results
   set.seed(1)
   result_xcorr_1 <- get_purity(pos, X = NULL, Xcorr = Xcorr, n = 20,
                                use_rfast = FALSE)
   set.seed(2)
   result_xcorr_2 <- get_purity(pos, X = NULL, Xcorr = Xcorr, n = 20,
                                use_rfast = FALSE)
+  expect_false(isTRUE(all.equal(result_xcorr_1, result_xcorr_2,
+                                tolerance = 10 * .Machine$double.eps)))
 
-  expect_equal(result_xcorr_1, expected, tolerance = 10 * .Machine$double.eps)
-  expect_identical(result_xcorr_1, result_xcorr_2)
+  # Xcorr path: with n >= length(pos), no subsampling → same full result
+  upper <- abs(Xcorr[pos, pos][upper.tri(Xcorr[pos, pos])])
+  expected <- c(min(upper), sum(upper) / length(upper), median(upper))
+  set.seed(1)
+  result_xcorr_full <- get_purity(pos, X = NULL, Xcorr = Xcorr, n = length(pos),
+                                  use_rfast = FALSE)
+  expect_equal(result_xcorr_full, expected, tolerance = 10 * .Machine$double.eps)
 
+  # X path: with n=20 < 120, subsampling applies → different seeds → different results
   set.seed(1)
   result_x_1 <- get_purity(pos, X = base_data$X, Xcorr = NULL, n = 20,
                            use_rfast = FALSE)


### PR DESCRIPTION
When running SuSiE on genomic regions with many variants (p > ~70K) using the XtX sufficient-statistics path, `get_cs.ss` crashes with 'malloc(): invalid size (unsorted)'. The crash originates in `safe_cov2cor(data$XtX)`, which calls `outer(d_inv, d_inv)` — this triggers a BLAS DGER routine that overflows 32-bit integer arithmetic for large matrix dimensions, corrupting memory.

Fix: Instead of materializing the full p×p correlation matrix via `safe_cov2cor`, I used a lazy scaled_XtX S3 class in `get_cs.ss`. Its `[` method computes only the needed purity submatrix (controlled by n_purity) using BLAS-free row/column scaling, completely avoiding DGER for any matrix size.

Additional fixes:
`get_cs.ss` early-exit bug: returning NULL when `min_abs_corr = NULL` even if `median_abs_corr` is set
`get_purity` now applies n_purity to the Xcorr path (previously ignored), preventing potential `t()` / `upper.tri()` overflow for very large CSs
Updated the unit test in `test_susie_utils.R` that specifically tested the old "Xcorr always uses all variables" behavior.

Please take a look and let me know if it's ok to merge these into the master and have a tag version?